### PR TITLE
Ensure existing functionality for users when adding a new brief and brief response statuses

### DIFF
--- a/app/main/views/briefs.py
+++ b/app/main/views/briefs.py
@@ -23,6 +23,8 @@ from ..helpers.frameworks import get_framework_and_lot
 from ...main import main, content_loader
 from ... import data_api_client
 
+PUBLISHED_BRIEF_STATUSES = ['live', 'closed', 'awarded']
+
 
 @main.route('/<int:brief_id>/question-and-answer-session', methods=['GET'])
 @login_required
@@ -256,7 +258,7 @@ def edit_brief_response(brief_id, brief_response_id, question_id=None):
 @main.route('/<int:brief_id>/responses/result')
 @login_required
 def view_response_result(brief_id):
-    brief = get_brief(data_api_client, brief_id, allowed_statuses=['live', 'closed'])
+    brief = get_brief(data_api_client, brief_id, allowed_statuses=PUBLISHED_BRIEF_STATUSES)
     brief_published_at = datetime.strptime(brief['publishedAt'], DATETIME_FORMAT)
     if not is_supplier_eligible_for_brief(data_api_client, current_user.supplier_id, brief):
         return _render_not_eligible_for_brief_error_page(brief)

--- a/tests/app/main/test_briefs.py
+++ b/tests/app/main/test_briefs.py
@@ -9,7 +9,7 @@ from dmapiclient import api_stubs, HTTPError
 from dmapiclient.audit import AuditTypes
 from dmutils.email.exceptions import EmailError
 
-from app.main.views.briefs import _render_not_eligible_for_brief_error_page
+from app.main.views.briefs import _render_not_eligible_for_brief_error_page, PUBLISHED_BRIEF_STATUSES
 
 from ..helpers import BaseApplicationTest, FakeMail
 
@@ -1580,12 +1580,12 @@ class TestResponseResultPageLegacyFlow(ResponseResultPageBothFlows):
         assert "**n2h two with markdown**" in data
         assert "<strong>n2h two with markdown</strong>" not in data
 
-    def test_view_response_result_submitted_ok_if_live_or_closed(self, data_api_client):
+    def test_view_response_result_submitted_ok_if_live_closed_or_awarded(self, data_api_client):
         self.set_framework_and_eligibility_for_api_client(data_api_client)
         data_api_client.find_brief_responses.return_value = self.brief_responses
         brief_copy = self.brief.copy()
 
-        for status in ('live', 'closed'):
+        for status in PUBLISHED_BRIEF_STATUSES:
             brief_copy['briefs']['status'] = status
             data_api_client.get_brief.return_value = brief_copy
 


### PR DESCRIPTION
We are adding a new
- 'awarded' status for briefs
- 'pending-awarded' and 'awarded' status for brief responses.

I have crawled through this repository looking for knock on effects when we shortly add a new 
 'award' status for briefs. I only found one location that we needed to change to ensure existing behaviour.

Note, I also found places using the helper method `supplier_has_a_brief_response`:

```
def supplier_has_a_brief_response(data_api_client, supplier_id, brief_id):
    brief_responses = data_api_client.find_brief_responses(brief_id=brief_id, supplier_id=supplier_id)['briefResponses']
    return len(brief_responses) != 0
```

This would need changes to ensure the original intended behaviour to request brief responses remains i.e. that we request 'submitted', 'pending-awarded', and 'awarded' brief responses. However, it instead makes sense to change this in the API instead so we include all of these by default - https://github.com/alphagov/digitalmarketplace-api/blob/master/app/main/views/brief_responses.py#L208.

The reviewer of this should ensure this has been actioned. (Done - see https://github.com/alphagov/digitalmarketplace-api/pull/622/commits/9e44345bb09356389b456e5e6990d43b23afa247)