### PR TITLE
Import opportunities dashboard

### DIFF
--- a/app/external/views/external.py
+++ b/app/external/views/external.py
@@ -6,8 +6,3 @@ external = Blueprint('external', __name__)
 @external.route('/suppliers')
 def dashboard():
     raise NotImplementedError()
-
-
-@external.route('/suppliers/frameworks/<framework_slug>/opportunities')
-def opportunities_dashboard():
-    raise NotImplementedError()

--- a/app/main/__init__.py
+++ b/app/main/__init__.py
@@ -22,5 +22,5 @@ def add_cache_control(response):
     return response
 
 
-from .views import briefs
+from .views import briefs, frameworks
 from . import errors

--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -1,0 +1,32 @@
+# coding: utf-8
+
+from flask import render_template, abort
+from flask_login import current_user
+from dmapiclient import APIError
+from ... import data_api_client
+from ...main import main
+from ..helpers import login_required
+
+
+@main.route('/frameworks/<framework_slug>', methods=['GET'])
+@login_required
+def opportunities_dashboard(framework_slug):
+    try:
+        framework = data_api_client.get_framework(slug=framework_slug)['frameworks']
+        supplier_framework = data_api_client.get_supplier_framework_info(
+            supplier_id=current_user.supplier_id,
+            framework_slug=framework['slug']
+        )['frameworkInterest']
+    except APIError as e:
+        abort(e.status_code)
+    if not (framework['framework'] == 'digital-outcomes-and-specialists' and supplier_framework['onFramework']):
+        abort(404)
+    opportunities = data_api_client.find_brief_responses(
+        supplier_id=current_user.supplier_id, framework=framework_slug
+    )['briefResponses']
+
+    return render_template(
+        "frameworks/opportunities_dashboard.html",
+        framework=framework,
+        completed=opportunities
+    ), 200

--- a/app/templates/briefs/view_response_result.html
+++ b/app/templates/briefs/view_response_result.html
@@ -148,7 +148,7 @@
 
   {%
     with
-      url = url_for("external.opportunities_dashboard", framework_slug=brief.frameworkSlug),
+      url = url_for(".opportunities_dashboard", framework_slug=brief.frameworkSlug),
       text = "Your {} applications".format(brief.frameworkName)
   %}
     {% include "toolkit/secondary-action-link.html" %}

--- a/app/templates/frameworks/opportunities_dashboard.html
+++ b/app/templates/frameworks/opportunities_dashboard.html
@@ -1,0 +1,65 @@
+{% extends "_base_page.html" %}
+{% import "toolkit/summary-table.html" as summary %}
+{% block page_title %}Opportunities Overview - Digital Marketplace{% endblock %}
+
+{% block breadcrumb %}
+  {%
+    with items = [
+    {
+        "link": "/",
+        "label": "Digital Marketplace"
+    },
+    {
+        "link": url_for("external.dashboard"),
+        "label": "Your account"
+    }
+    ]
+  %}
+    {% include "toolkit/breadcrumb.html" %}
+  {% endwith %}
+{% endblock %}
+
+{% block main_content %}
+
+    <div class="grid-row">
+
+        <div class="column-two-thirds">
+            {% with
+                heading = 'Your {} opportunities'.format(framework.name),
+                smaller = True
+            %}
+            {% include 'toolkit/page-heading.html' %}
+            {% endwith %}
+        </div>
+    </div>
+
+  <p>
+    <a href={{ "/{}/opportunities".format(framework.framework) }}>
+      Search for other opportunities
+    </a>
+  </p>
+
+
+{{ summary.heading("Applications you’ve made", id="submitted-opportunities") }}
+{% call(item) summary.list_table(
+    completed|sort(attribute='brief.applicationsClosedAt', reverse=True),
+    caption="Completed opportunities",
+    empty_message="You haven’t applied to any opportunities",
+    field_headings=[
+        "Opportunity",
+        "Closing date",
+        summary.hidden_field_heading("View")
+    ],
+    field_headings_visible=True
+) %}
+
+    {% call summary.row() %}
+        {% call summary.field(first=True, wide=True) %}
+            <a href={{ "/{}/opportunities/{}".format(framework.framework, item.briefId) }}>{{ item.brief.title }}</a>
+        {% endcall %}
+        {{ summary.text(item.brief.applicationsClosedAt|dateformat) }}
+        {{ summary.edit_link("View application", url_for(".view_response_result", brief_id=item.briefId)) if not item.brief.status == 'withdrawn' else summary.text() }}
+    {% endcall %}
+{% endcall %}
+
+{% endblock %}

--- a/tests/app/main/test_briefs.py
+++ b/tests/app/main/test_briefs.py
@@ -1,4 +1,4 @@
-# coding: utf-8
+# -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
 import mock

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -1,0 +1,146 @@
+# -*- coding: utf-8 -*-
+import mock
+from lxml import html
+from dmapiclient import APIError
+from ..helpers import BaseApplicationTest
+
+
+@mock.patch('app.main.views.frameworks.data_api_client', autospec=True)
+class TestOpportunitiesDashboard(BaseApplicationTest):
+    opportunities_dashboard_url = '/suppliers/opportunities/frameworks/digital-outcomes-and-specialists-2'
+
+    def setup_method(self, method):
+        super(TestOpportunitiesDashboard, self).setup_method(method)
+        self.framework_response = {
+            'frameworks': {
+                'slug': 'digital-outcomes-and-specialists-2',
+                'framework': 'digital-outcomes-and-specialists'
+            }
+        }
+        self.supplier_framework_response = {
+            'frameworkInterest': {'onFramework': True}
+        }
+        self.find_brief_responses_response = {'briefResponses': [
+            {
+                'briefId': 100,
+                'brief': {
+                    'title': 'Highest date, submitted, lowest id',
+                    'applicationsClosedAt': '2017-06-08T10:26:21.538917Z',
+                    'status': 'closed',
+                    'frameworkSlug': 'digital-outcomes-and-specialists-2'
+                },
+                'status': 'submitted',
+            },
+            {
+                'briefId': 1829,
+                'brief': {
+                    'title': 'Lowest date, submitted, mid id',
+                    'applicationsClosedAt': '2017-06-06T10:26:21.538917Z',
+                    'status': 'closed',
+                    'frameworkSlug': 'digital-outcomes-and-specialists-2'
+                },
+                'status': 'submitted',
+            },
+            {
+                'briefId': 4734,
+                'brief': {
+                    'title': 'Mid date, submitted, highest id',
+                    'applicationsClosedAt': '2017-06-07T10:26:21.538917Z',
+                    'status': 'withdrawn',
+                    'frameworkSlug': 'digital-outcomes-and-specialists-2'
+                },
+                'status': 'submitted',
+            }
+        ]}
+
+    def get_table_rows_by_id(self, table_id, data_api_client):
+        """Helper function to get our 3 table rows as strings."""
+        data_api_client.get_framework.return_value = self.framework_response
+        data_api_client.get_supplier_framework_info.return_value = self.supplier_framework_response
+        data_api_client.find_brief_responses.return_value = self.find_brief_responses_response
+        with self.client:
+            self.login()
+            res = self.client.get(self.opportunities_dashboard_url)
+
+            doc = html.fromstring(res.get_data(as_text=True))
+            xpath_string = ".//*[@id='{}']/following-sibling::table[1]".format(table_id)
+
+            table = doc.xpath(xpath_string)[0]
+            rows = table.find_class('summary-item-row')
+
+            assert res.status_code == 200
+        return [i.xpath('string()') for i in rows]
+
+    def test_request_works_and_correct_data_is_fetched(self, data_api_client):
+        data_api_client.get_supplier_framework_info.return_value = self.supplier_framework_response
+        data_api_client.get_framework.return_value = self.framework_response
+        with self.client:
+            self.login()
+            resp = self.client.get(self.opportunities_dashboard_url)
+            assert resp.status_code == 200
+            data_api_client.find_brief_responses.assert_called_once_with(
+                supplier_id=1234,
+                framework='digital-outcomes-and-specialists-2'
+            )
+
+    def test_404_if_framework_does_not_exist(self, data_api_client):
+        data_api_client.get_framework.side_effect = APIError(mock.Mock(status_code=404))
+        with self.client:
+            self.login()
+            resp = self.client.get('/suppliers/frameworks/does-not-exist/opportunities')
+
+            assert resp.status_code == 404
+
+    def test_404_if_supplier_framework_does_not_exist(self, data_api_client):
+        data_api_client.get_framework.return_value = self.framework_response
+        data_api_client.get_supplier_framework_info.side_effect = APIError(mock.Mock(status_code=404))
+        with self.client:
+            self.login()
+            resp = self.client.get(self.opportunities_dashboard_url)
+
+            assert resp.status_code == 404
+
+    def test_404_if_framework_is_not_dos(self, data_api_client):
+        self.framework_response['frameworks'].update({'slug': 'g-cloud-9', 'framework': 'g-cloud'})
+        data_api_client.get_framework.return_value = self.framework_response
+        data_api_client.get_supplier_framework_info.return_value = self.supplier_framework_response
+        with self.client:
+            self.login()
+            resp = self.client.get('/suppliers/frameworks/g-cloud-9/opportunities')
+
+            assert resp.status_code == 404
+
+    def test_404_if_supplier_not_on_framework(self, data_api_client):
+        data_api_client.get_framework.return_value = self.framework_response
+        self.supplier_framework_response['frameworkInterest'].update(
+            {'onFramework': False}
+        )
+        data_api_client.get_supplier_framework_info.return_value = self.supplier_framework_response
+        with self.client:
+            self.login()
+            resp = self.client.get(self.opportunities_dashboard_url)
+
+            assert resp.status_code == 404
+
+    def test_completed_list_of_opportunities(self, data_api_client):
+        """Assert the 'Completed opportunities' table on this page contains the correct values."""
+        first_row, second_row, third_row = self.get_table_rows_by_id('submitted-opportunities', data_api_client)
+
+        assert 'Highest date, submitted, lowest id' in first_row
+        assert 'Thursday 8 June 2017' in first_row
+        assert 'View application' in first_row
+
+    def test_completed_list_of_opportunities_ordered_by_applications_closed_at(self, data_api_client):
+        """Assert the 'Completed opportunities' table on this page contains the brief responses in the correct order."""
+        first_row, second_row, third_row = self.get_table_rows_by_id('submitted-opportunities', data_api_client)
+
+        assert 'Highest date' in first_row
+        assert 'Mid date' in second_row
+        assert 'Lowest date' in third_row
+
+    def test_withdrawn_has_no_link_to_application(self, data_api_client):
+        first_row, second_row, third_row = self.get_table_rows_by_id('submitted-opportunities', data_api_client)
+
+        assert 'View application' in first_row
+        assert 'View application' not in second_row
+        assert 'View application' in third_row


### PR DESCRIPTION
MUST BE MERGED BEFORE [https://github.com/alphagov/digitalmarketplace-supplier-frontend/pull/731](https://github.com/alphagov/digitalmarketplace-supplier-frontend/pull/731)

The opportunites dashboard for a supplier shows them their responses to
opportunities. It makes sense to move it to the brief responses frontend
app.

The url is slightly different to where it was before, so a 301 redirect
will be put in place in the supplier app to point to this new url.

This means we can also get rid of one of the external links.