### PR TITLE
Show application status on application dashboard

### DIFF
--- a/app/external/views/external.py
+++ b/app/external/views/external.py
@@ -6,3 +6,8 @@ external = Blueprint('external', __name__)
 @external.route('/suppliers')
 def dashboard():
     raise NotImplementedError()
+
+
+@external.route('/<string:framework_framework>/opportunities/<int:brief_id>/')
+def buyer_frontend_get_brief_by_id(framework_framework, brief_id):
+    raise NotImplementedError()

--- a/app/main/views/briefs.py
+++ b/app/main/views/briefs.py
@@ -23,7 +23,7 @@ from ..helpers.frameworks import get_framework_and_lot
 from ...main import main, content_loader
 from ... import data_api_client
 
-PUBLISHED_BRIEF_STATUSES = ['live', 'closed', 'awarded', 'cancelled', 'unsuccessful']
+PUBLISHED_BRIEF_STATUSES = ['live', 'closed', 'awarded', 'cancelled', 'unsuccessful', 'withdrawn']
 
 
 @main.route('/<int:brief_id>/question-and-answer-session', methods=['GET'])

--- a/app/templates/briefs/view_response_result.html
+++ b/app/templates/briefs/view_response_result.html
@@ -84,6 +84,8 @@
         {% include 'toolkit/page-heading.html' %}
     {% endwith %}
 
+    <a href="{{ url_for('external.buyer_frontend_get_brief_by_id', framework_framework='digital-outcomes-and-specialists', brief_id=brief.id) }}">View the opportunity{{ ' and its outcome' if brief.status in ["awarded", "cancelled", "unsuccessful"] }}</a>
+
     {% if brief.status in ["live", "closed"] %}
       <div class="dmspeak">
       {% if result_state == "submitted_ok" %}

--- a/app/templates/briefs/view_response_result.html
+++ b/app/templates/briefs/view_response_result.html
@@ -11,12 +11,12 @@
         "label": "Digital Marketplace"
       },
       {
-        "link": "/{}/opportunities".format(brief.frameworkFramework),
-        "label": "Supplier opportunities"
+        "link": url_for("external.dashboard"),
+        "label": "Your account"
       },
       {
-        "link": "/{}/opportunities/{}".format(brief.frameworkFramework, brief.id),
-        "label": brief.title
+        "link": url_for(".opportunities_dashboard", framework_slug=brief.frameworkSlug),
+        "label": "Your {} opportunities".format(brief.frameworkName)
       },
     ]
   %}
@@ -150,7 +150,7 @@
   {%
     with
       url = url_for(".opportunities_dashboard", framework_slug=brief.frameworkSlug),
-      text = "Your {} applications".format(brief.frameworkName)
+      text = "Your {} opportunities".format(brief.frameworkName)
   %}
     {% include "toolkit/secondary-action-link.html" %}
   {% endwith %}

--- a/app/templates/briefs/view_response_result.html
+++ b/app/templates/briefs/view_response_result.html
@@ -64,7 +64,7 @@
         {%
         with
         message = message,
-        type = "destructive" if category == "error" else category
+        type = "destructive-without-action" if category == "error" else category
         %}
           {% include "toolkit/notification-banner.html" %}
         {% endwith %}

--- a/app/templates/briefs/view_response_result.html
+++ b/app/templates/briefs/view_response_result.html
@@ -32,23 +32,12 @@
   {% if ("error", "already_applied") in messages %}
     {%
     with
-    message = "You’ve already applied so you can’t apply again.".format(brief.title) if result_state == "submitted_ok"
-      else "You already applied but you didn’t meet the essential requirements.".format(brief.title),
+    message = "You’ve already applied so you can’t apply again.".format(brief.title),
     type = "destructive"
     %}
       {% include "toolkit/notification-banner.html" %}
     {% endwith %}
   {% else %}
-    {# Unsuccessful application #}
-    {% if result_state == "submitted_unsuccessful" %}
-      {%
-      with
-      message = "You don’t meet all the essential requirements.".format(brief.title),
-      type = "destructive"
-      %}
-        {% include "toolkit/notification-banner.html" %}
-      {% endwith %}
-    {% endif %}
     {# Flash messages/ first success handling/ default #}
     {% for category, message in messages %}
       {% if message == "submitted_first" %}

--- a/app/templates/briefs/view_response_result.html
+++ b/app/templates/briefs/view_response_result.html
@@ -39,17 +39,8 @@
       {% include "toolkit/notification-banner.html" %}
     {% endwith %}
   {% else %}
-    {# Successful application #}
-    {% if result_state == "submitted_ok"  %}
-      {%
-      with
-      message = "Your application has been submitted.".format(brief.title),
-      type = "success"
-      %}
-        {% include "toolkit/notification-banner.html" %}
-      {% endwith %}
     {# Unsuccessful application #}
-    {% elif result_state == "submitted_unsuccessful" %}
+    {% if result_state == "submitted_unsuccessful" %}
       {%
       with
       message = "You don’t meet all the essential requirements.".format(brief.title),
@@ -60,17 +51,24 @@
     {% endif %}
     {# Flash messages/ first success handling/ default #}
     {% for category, message in messages %}
-      {%
-      with
-      message = message,
-      type = "destructive" if category == "error" else category
-      %}
-        {% if message == "submitted_first" %}
+      {% if message == "submitted_first" %}
+        {%
+        with
+        message = "Your application has been submitted.",
+        type = "success"
+        %}
           <span data-analytics="trackPageView" data-url={{ "{}?result=success".format(request.path) }}></span>
-        {% else %}
           {% include "toolkit/notification-banner.html" %}
-        {% endif %}
-      {% endwith %}
+        {% endwith %}
+      {% else %}
+        {%
+        with
+        message = message,
+        type = "destructive" if category == "error" else category
+        %}
+          {% include "toolkit/notification-banner.html" %}
+        {% endwith %}
+      {% endif %}
     {% endfor %}
   {% endif %}
 {% endwith %}

--- a/app/templates/briefs/view_response_result.html
+++ b/app/templates/briefs/view_response_result.html
@@ -76,7 +76,7 @@
 <div class="grid-row">
   <div class="column-two-thirds">
     {% with
-      heading = "Your application for ‘{}’".format(brief.title),
+      heading = "Your application for {}".format(brief.title),
       smaller = true
       %}
         {% include 'toolkit/page-heading.html' %}

--- a/app/templates/briefs/view_response_result.html
+++ b/app/templates/briefs/view_response_result.html
@@ -71,60 +71,62 @@
         {% include 'toolkit/page-heading.html' %}
     {% endwith %}
 
-    <a href="{{ url_for('external.buyer_frontend_get_brief_by_id', framework_framework='digital-outcomes-and-specialists', brief_id=brief.id) }}">View the opportunity{{ ' and its outcome' if brief.status in ["awarded", "cancelled", "unsuccessful"] }}</a>
+    <div class="dmspeak">
+      <p>
+        <a href="{{ url_for('external.buyer_frontend_get_brief_by_id', framework_framework='digital-outcomes-and-specialists', brief_id=brief.id) }}">View the opportunity{{ ' and its outcome' if brief.status in ["awarded", "cancelled", "unsuccessful"] }}</a>
+      </p>
 
-    {% if brief.status in ["live", "closed"] %}
-      <div class="dmspeak">
-      {% if result_state == "submitted_ok" %}
-        <h2 class="summary-item-heading">What happens next</h2>
+      {% if brief.status in ["live", "closed"] %}
+        {% if result_state == "submitted_ok" %}
+          <h2 class="summary-item-heading">What happens next</h2>
 
-        {% if 'essentialRequirementsMet' in brief_response %}
-          <h3>Shortlist</h3>
+          {% if 'essentialRequirementsMet' in brief_response %}
+            <h3>Shortlist</h3>
 
-          <p>When the opportunity closes, the buyer will score your evidence. If you’re one of the top {{ brief.get('numberOfSuppliers') }} suppliers, you'll go through to the evaluation stage.</p>
-          <p>The buyer will tell you if you're not successful.</p>
+            <p>When the opportunity closes, the buyer will score your evidence. If you’re one of the top {{ brief.get('numberOfSuppliers') }} suppliers, you'll go through to the evaluation stage.</p>
+            <p>The buyer will tell you if you're not successful.</p>
 
-          <h3>Evaluation</h3>
+            <h3>Evaluation</h3>
 
-          <div class="explanation-list">
-            <p class="lead">At the evaluation stage, the buyer will ask you to provide:</p>
-            <ul class="list-bullet">
-              <li>
-              {% if brief.lotSlug == "digital-specialists" %}
-                evidence of the specialist’s skills and experience
-              {% else %}
-                evidence of your skills and experience
-              {% endif %}
-              </li>
-              {% if brief.lotSlug != "digital-specialists" %}
-              <li>your proposal</li>
-              {% endif %}
-            </ul>
-          </div>
-          <div class="explanation-list">
-            <p class="lead">The buyer will use the assessment methods listed in their requirements to evaluate your evidence. They’ll use:</p>
-            <ul class="list-bullet">
-              {% for eval_type in brief_summary.get_question('evaluationType').value %}
-                <li>{{ 'an' if eval_type == 'Interview' else 'a' }} {{ eval_type|lower }}</li>
-              {% endfor %}
-            </ul>
-          </div>
+            <div class="explanation-list">
+              <p class="lead">At the evaluation stage, the buyer will ask you to provide:</p>
+              <ul class="list-bullet">
+                <li>
+                {% if brief.lotSlug == "digital-specialists" %}
+                  evidence of the specialist’s skills and experience
+                {% else %}
+                  evidence of your skills and experience
+                {% endif %}
+                </li>
+                {% if brief.lotSlug != "digital-specialists" %}
+                <li>your proposal</li>
+                {% endif %}
+              </ul>
+            </div>
+            <div class="explanation-list">
+              <p class="lead">The buyer will use the assessment methods listed in their requirements to evaluate your evidence. They’ll use:</p>
+              <ul class="list-bullet">
+                {% for eval_type in brief_summary.get_question('evaluationType').value %}
+                  <li>{{ 'an' if eval_type == 'Interview' else 'a' }} {{ eval_type|lower }}</li>
+                {% endfor %}
+              </ul>
+            </div>
+            <p>
+              Your evidence must describe the skills and experience of the {{ 'person' if brief.lotSlug == "digital-specialists" else 'people' }} who’ll be working on the project.
+            </p>
+            <p>
+              The buyer will score all suppliers who reached the evaluation stage using the weightings they published with their requirements. They’ll provide feedback if you’re unsuccessful.
+            </p>
+          {% else %}
+            {% include 'briefs/_legacy_view_response_result_content.html' %}
+          {% endif %}
+        {% elif result_state == "submitted_unsuccessful" %}
           <p>
-            Your evidence must describe the skills and experience of the {{ 'person' if brief.lotSlug == "digital-specialists" else 'people' }} who’ll be working on the project.
+            You don’t have all the essential skills and experience so you can’t go through to the shortlisting stage.
           </p>
-          <p>
-            The buyer will score all suppliers who reached the evaluation stage using the weightings they published with their requirements. They’ll provide feedback if you’re unsuccessful.
-          </p>
-        {% else %}
-          {% include 'briefs/_legacy_view_response_result_content.html' %}
         {% endif %}
-      {% elif result_state == "submitted_unsuccessful" %}
-        <p>
-          You don’t have all the essential skills and experience so you can’t go through to the shortlisting stage.
-        </p>
       {% endif %}
-      </div>
-    {% endif %}
+    </div>
   </div>
 </div>
 

--- a/app/templates/briefs/view_response_result.html
+++ b/app/templates/briefs/view_response_result.html
@@ -84,57 +84,58 @@
         {% include 'toolkit/page-heading.html' %}
     {% endwith %}
 
-    <div class="dmspeak">
+    {% if brief.status in ["live", "closed"] %}
+      <div class="dmspeak">
+      {% if result_state == "submitted_ok" %}
+        <h2 class="summary-item-heading">What happens next</h2>
 
-    {% if result_state == "submitted_ok" %}
-      <h2 class="summary-item-heading">What happens next</h2>
+        {% if 'essentialRequirementsMet' in brief_response %}
+          <h3>Shortlist</h3>
 
-      {% if 'essentialRequirementsMet' in brief_response %}
-        <h3>Shortlist</h3>
+          <p>When the opportunity closes, the buyer will score your evidence. If you’re one of the top {{ brief.get('numberOfSuppliers') }} suppliers, you'll go through to the evaluation stage.</p>
+          <p>The buyer will tell you if you're not successful.</p>
 
-        <p>When the opportunity closes, the buyer will score your evidence. If you’re one of the top {{ brief.get('numberOfSuppliers') }} suppliers, you'll go through to the evaluation stage.</p>
-        <p>The buyer will tell you if you're not successful.</p>
+          <h3>Evaluation</h3>
 
-        <h3>Evaluation</h3>
-
-        <div class="explanation-list">
-          <p class="lead">At the evaluation stage, the buyer will ask you to provide:</p>
-          <ul class="list-bullet">
-            <li>
-            {% if brief.lotSlug == "digital-specialists" %}
-              evidence of the specialist’s skills and experience
-            {% else %}
-              evidence of your skills and experience
-            {% endif %}
-            </li>
-            {% if brief.lotSlug != "digital-specialists" %}
-            <li>your proposal</li>
-            {% endif %}
-          </ul>
-        </div>
-        <div class="explanation-list">
-          <p class="lead">The buyer will use the assessment methods listed in their requirements to evaluate your evidence. They’ll use:</p>
-          <ul class="list-bullet">
-            {% for eval_type in brief_summary.get_question('evaluationType').value %}
-              <li>{{ 'an' if eval_type == 'Interview' else 'a' }} {{ eval_type|lower }}</li>
-            {% endfor %}
-          </ul>
-        </div>
+          <div class="explanation-list">
+            <p class="lead">At the evaluation stage, the buyer will ask you to provide:</p>
+            <ul class="list-bullet">
+              <li>
+              {% if brief.lotSlug == "digital-specialists" %}
+                evidence of the specialist’s skills and experience
+              {% else %}
+                evidence of your skills and experience
+              {% endif %}
+              </li>
+              {% if brief.lotSlug != "digital-specialists" %}
+              <li>your proposal</li>
+              {% endif %}
+            </ul>
+          </div>
+          <div class="explanation-list">
+            <p class="lead">The buyer will use the assessment methods listed in their requirements to evaluate your evidence. They’ll use:</p>
+            <ul class="list-bullet">
+              {% for eval_type in brief_summary.get_question('evaluationType').value %}
+                <li>{{ 'an' if eval_type == 'Interview' else 'a' }} {{ eval_type|lower }}</li>
+              {% endfor %}
+            </ul>
+          </div>
+          <p>
+            Your evidence must describe the skills and experience of the {{ 'person' if brief.lotSlug == "digital-specialists" else 'people' }} who’ll be working on the project.
+          </p>
+          <p>
+            The buyer will score all suppliers who reached the evaluation stage using the weightings they published with their requirements. They’ll provide feedback if you’re unsuccessful.
+          </p>
+        {% else %}
+          {% include 'briefs/_legacy_view_response_result_content.html' %}
+        {% endif %}
+      {% elif result_state == "submitted_unsuccessful" %}
         <p>
-          Your evidence must describe the skills and experience of the {{ 'person' if brief.lotSlug == "digital-specialists" else 'people' }} who’ll be working on the project.
+          You don’t have all the essential skills and experience so you can’t go through to the shortlisting stage.
         </p>
-        <p>
-          The buyer will score all suppliers who reached the evaluation stage using the weightings they published with their requirements. They’ll provide feedback if you’re unsuccessful.
-        </p>
-      {% else %}
-        {% include 'briefs/_legacy_view_response_result_content.html' %}
       {% endif %}
-    {% elif result_state == "submitted_unsuccessful" %}
-      <p>
-        You don’t have all the essential skills and experience so you can’t go through to the shortlisting stage.
-      </p>
+      </div>
     {% endif %}
-    </div>
   </div>
 </div>
 

--- a/app/templates/frameworks/opportunities_dashboard.html
+++ b/app/templates/frameworks/opportunities_dashboard.html
@@ -47,7 +47,7 @@
     empty_message="You haven’t applied to any opportunities",
     field_headings=[
         "Opportunity",
-        "Closing date",
+        "Deadline",
         summary.hidden_field_heading("View")
     ],
     field_headings_visible=True

--- a/app/templates/frameworks/opportunities_dashboard.html
+++ b/app/templates/frameworks/opportunities_dashboard.html
@@ -47,7 +47,8 @@
     empty_message="You haven’t applied to any opportunities",
     field_headings=[
         "Application",
-        "Deadline"
+        "Deadline",
+        "Status",
     ],
     field_headings_visible=True
 ) %}
@@ -57,6 +58,19 @@
             <a href="{{ url_for('.view_response_result', brief_id=item.briefId) }}">{{ item.brief.title }}</a>
         {% endcall %}
         {{ summary.text(item.brief.applicationsClosedAt|dateformat) }}
+        {% if item.brief.status == "cancelled" %}
+            {{ summary.text('Opportunity cancelled') }}
+        {% elif item.brief.status == "unsuccessful" %}
+            {{ summary.text('Not won') }}
+        {% elif item.brief.status == "withdrawn" %}
+            {{ summary.text('Opportunity withdrawn') }}
+        {% elif item.brief.status == "closed" or item.brief.status == "live" %}
+            {{ summary.text('Submitted') }}
+        {% elif item.status == "awarded" %}
+            {{ summary.text('Won') }}
+        {% elif item.brief.status == "awarded" %}
+            {{ summary.text('Not won') }}
+        {% endif %}
     {% endcall %}
 {% endcall %}
 

--- a/app/templates/frameworks/opportunities_dashboard.html
+++ b/app/templates/frameworks/opportunities_dashboard.html
@@ -46,19 +46,17 @@
     caption="Completed opportunities",
     empty_message="You haven’t applied to any opportunities",
     field_headings=[
-        "Opportunity",
-        "Deadline",
-        summary.hidden_field_heading("View")
+        "Application",
+        "Deadline"
     ],
     field_headings_visible=True
 ) %}
 
     {% call summary.row() %}
         {% call summary.field(first=True, wide=True) %}
-            <a href={{ "/{}/opportunities/{}".format(framework.framework, item.briefId) }}>{{ item.brief.title }}</a>
+            <a href="{{ url_for('.view_response_result', brief_id=item.briefId) }}">{{ item.brief.title }}</a>
         {% endcall %}
         {{ summary.text(item.brief.applicationsClosedAt|dateformat) }}
-        {{ summary.edit_link("View application", url_for(".view_response_result", brief_id=item.briefId)) if not item.brief.status == 'withdrawn' else summary.text() }}
     {% endcall %}
 {% endcall %}
 

--- a/tests/app/helpers.py
+++ b/tests/app/helpers.py
@@ -8,6 +8,7 @@ from app import data_api_client
 from datetime import datetime, timedelta
 from dmutils.formats import DATETIME_FORMAT
 import pytest
+from lxml import html
 
 
 class BaseApplicationTest(object):
@@ -241,6 +242,25 @@ class BaseApplicationTest(object):
     def assert_no_flashes(self):
         with self.client.session_transaction() as session:
             assert not session.get("_flashes")
+
+    def assert_breadcrumbs(self, response, expected_breadcrumbs):
+        """
+        Example expected breadcrumbs:
+        expected_breadcrumbs = [
+            ('Digital Marketplace', '/'),
+            ('Supplier opportunities', '/digital-outcomes-and-specialists/opportunities'),
+            ('Brief title', '/digital-outcomes-and-specialists/opportunities/127'),
+        ]
+        """
+        breadcrumbs = html.fromstring(response.get_data(as_text=True)).xpath(
+            '//*[@id="global-breadcrumb"]/nav/ol/li'
+        )
+
+        assert len(breadcrumbs) == len(expected_breadcrumbs)
+
+        for index, link in enumerate(expected_breadcrumbs):
+            assert breadcrumbs[index].find('a').text_content().strip() == link[0]
+            assert breadcrumbs[index].find('a').get('href').strip() == link[1]
 
 
 class FakeMail(object):

--- a/tests/app/main/test_briefs.py
+++ b/tests/app/main/test_briefs.py
@@ -1668,29 +1668,10 @@ class TestResponseResultPageLegacyFlow(ResponseResultPageBothFlows):
         res = self.client.get('/suppliers/opportunities/1234/responses/result')
 
         assert res.status_code == 200
-        doc = html.fromstring(res.get_data(as_text=True))
-        assert doc.xpath('//p[contains(@class, "banner-message")]')[0].text.strip() == \
-            "You don’t meet all the essential requirements."
-
-    def test_correct_already_applied_flash_message_appears_in_result_page_if_no_essential_requirements(self, data_api_client):  # noqa
-        # Requests to either the start page of a response or any of its question pages
-        # will redirect to the results page with 'already applied' a flash message.
-        # Test this message is rendered when present.
-
-        self.brief_responses['briefResponses'][0]['essentialRequirements'][1] = False
-
-        self.set_framework_and_eligibility_for_api_client(data_api_client)
-        data_api_client.get_brief.return_value = self.brief
-        data_api_client.find_brief_responses.return_value = self.brief_responses
-        with self.client.session_transaction() as session:
-            session['_flashes'] = [(u'error', u'already_applied')]
-
-        res = self.client.get('/suppliers/opportunities/1234/responses/result')
-
-        assert res.status_code == 200
-        doc = html.fromstring(res.get_data(as_text=True))
-        assert doc.xpath('//p[contains(@class, "banner-message")]')[0].text.strip() == \
-            "You already applied but you didn’t meet the essential requirements."
+        data = res.get_data(as_text=True)
+        expected_content = ("You don’t have all the essential skills and experience so you can’t go through to the "
+                            "shortlisting stage.")
+        assert expected_content in data
 
     def test_essential_skills_shown_with_response(self, data_api_client):
         self.set_framework_and_eligibility_for_api_client(data_api_client)
@@ -2012,9 +1993,7 @@ class TestResponseResultPage(ResponseResultPageBothFlows, BriefResponseTestHelpe
         # Assert we get the correct banner message (and only the correct one).
         assert 'Your application has been submitted.' in data
 
-        assert 'You don’t meet all the essential requirements.' not in data
         assert 'You’ve already applied so you can’t apply again.' not in data
-        assert 'You already applied but you didn’t meet the essential requirements.' not in data
 
 
 @mock.patch("app.main.views.briefs.data_api_client", autospec=True)

--- a/tests/app/main/test_briefs.py
+++ b/tests/app/main/test_briefs.py
@@ -1489,6 +1489,17 @@ class ResponseResultPageBothFlows(BaseApplicationTest, BriefResponseTestHelpers)
         res = self.client.get('/suppliers/opportunities/1234/responses/result')
         assert res.status_code == 200
 
+    def test_view_response_shows_page_title_with_brief_name(self, data_api_client):
+        self.set_framework_and_eligibility_for_api_client(data_api_client)
+        data_api_client.get_brief.return_value = self.brief
+        data_api_client.find_brief_responses.return_value = self.brief_responses
+
+        res = self.client.get('/suppliers/opportunities/1234/responses/result')
+
+        assert res.status_code == 200
+        doc = html.fromstring(res.get_data(as_text=True))
+        assert doc.xpath('//h1')[0].text.strip() == "Your application for I need a thing to do a thing"
+
     def test_already_applied_flash_message_appears_in_result_page(self, data_api_client):
         # Requests to either the start page of a response or any of its question pages
         # will redirect to the results page with 'already applied' a flash message.
@@ -1504,7 +1515,6 @@ class ResponseResultPageBothFlows(BaseApplicationTest, BriefResponseTestHelpers)
 
         assert res.status_code == 200
         doc = html.fromstring(res.get_data(as_text=True))
-        assert doc.xpath('//h1')[0].text.strip() == "Your application for ‘I need a thing to do a thing’"
         assert doc.xpath('//p[contains(@class, "banner-message")]')[0].text.strip() == \
             "You’ve already applied so you can’t apply again."
 
@@ -1661,7 +1671,6 @@ class TestResponseResultPageLegacyFlow(ResponseResultPageBothFlows):
 
         assert res.status_code == 200
         doc = html.fromstring(res.get_data(as_text=True))
-        assert doc.xpath('//h1')[0].text.strip() == "Your application for ‘I need a thing to do a thing’"
         assert doc.xpath('//p[contains(@class, "banner-message")]')[0].text.strip() == \
             "You don’t meet all the essential requirements."
 
@@ -1682,7 +1691,6 @@ class TestResponseResultPageLegacyFlow(ResponseResultPageBothFlows):
 
         assert res.status_code == 200
         doc = html.fromstring(res.get_data(as_text=True))
-        assert doc.xpath('//h1')[0].text.strip() == "Your application for ‘I need a thing to do a thing’"
         assert doc.xpath('//p[contains(@class, "banner-message")]')[0].text.strip() == \
             "You already applied but you didn’t meet the essential requirements."
 

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -62,14 +62,13 @@ class TestOpportunitiesDashboard(BaseApplicationTest):
             self.login()
             res = self.client.get(self.opportunities_dashboard_url)
 
+            assert res.status_code == 200
+
             doc = html.fromstring(res.get_data(as_text=True))
             xpath_string = ".//*[@id='{}']/following-sibling::table[1]".format(table_id)
-
             table = doc.xpath(xpath_string)[0]
             rows = table.find_class('summary-item-row')
-
-            assert res.status_code == 200
-        return [i.xpath('string()') for i in rows]
+            return rows
 
     def test_request_works_and_correct_data_is_fetched(self, data_api_client):
         data_api_client.get_supplier_framework_info.return_value = self.supplier_framework_response
@@ -126,21 +125,14 @@ class TestOpportunitiesDashboard(BaseApplicationTest):
         """Assert the 'Completed opportunities' table on this page contains the correct values."""
         first_row, second_row, third_row = self.get_table_rows_by_id('submitted-opportunities', data_api_client)
 
-        assert 'Highest date, submitted, lowest id' in first_row
-        assert 'Thursday 8 June 2017' in first_row
-        assert 'View application' in first_row
+        assert 'Highest date, submitted, lowest id' in first_row.text_content()
+        assert first_row.xpath('*//a/@href')[0] == '/suppliers/opportunities/100/responses/result'
+        assert 'Thursday 8 June 2017' in first_row.text_content()
 
     def test_completed_list_of_opportunities_ordered_by_applications_closed_at(self, data_api_client):
         """Assert the 'Completed opportunities' table on this page contains the brief responses in the correct order."""
         first_row, second_row, third_row = self.get_table_rows_by_id('submitted-opportunities', data_api_client)
 
-        assert 'Highest date' in first_row
-        assert 'Mid date' in second_row
-        assert 'Lowest date' in third_row
-
-    def test_withdrawn_has_no_link_to_application(self, data_api_client):
-        first_row, second_row, third_row = self.get_table_rows_by_id('submitted-opportunities', data_api_client)
-
-        assert 'View application' in first_row
-        assert 'View application' not in second_row
-        assert 'View application' in third_row
+        assert 'Highest date' in first_row.text_content()
+        assert 'Mid date' in second_row.text_content()
+        assert 'Lowest date' in third_row.text_content()

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -137,108 +137,50 @@ class TestOpportunitiesDashboard(BaseApplicationTest):
         assert 'Mid date' in second_row.text_content()
         assert 'Lowest date' in third_row.text_content()
 
-    def test_completed_list_of_opportunities_gives_correct_status_for_each_application(self, data_api_client):
-        self.find_brief_responses_response = {'briefResponses': [
-            {
-                'briefId': 1,
-                'brief': {
-                    'title': 'Submitted brief response for open opportunity',
-                    'applicationsClosedAt': '2017-06-09T10:26:21.538917Z',
-                    'status': 'live',
-                    'frameworkSlug': 'digital-outcomes-and-specialists-2'
+    def _get_brief_response_dashboard_status(self, data_api_client, brief_response_status, brief_status):
+        self.find_brief_responses_response = {
+            'briefResponses': [
+                {
+                    'briefId': 1,
+                    'brief': {
+                        'title': 'Submitted brief response for open opportunity',
+                        'applicationsClosedAt': '2017-06-09T10:26:21.538917Z',
+                        'status': brief_status,
+                        'frameworkSlug': 'digital-outcomes-and-specialists-2'
+                    },
+                    'status': brief_response_status,
                 },
-                'status': 'submitted',
-            },
-            {
-                'briefId': 2,
-                'brief': {
-                    'title': 'Submitted brief response for closed brief',
-                    'applicationsClosedAt': '2017-06-08T10:26:21.538917Z',
-                    'status': 'closed',
-                    'frameworkSlug': 'digital-outcomes-and-specialists-2'
-                },
-                'status': 'submitted',
-            },
-            {
-                'briefId': 3,
-                'brief': {
-                    'title': 'Cancelled opportunity',
-                    'applicationsClosedAt': '2017-06-07T10:26:21.538917Z',
-                    'status': 'cancelled',
-                    'frameworkSlug': 'digital-outcomes-and-specialists-2'
-                },
-                'status': 'submitted',
-            },
-            {
-                'briefId': 4,
-                'brief': {
-                    'title': 'Unsuccessful opportunity',
-                    'applicationsClosedAt': '2017-06-06T10:26:21.538917Z',
-                    'status': 'unsuccessful',
-                    'frameworkSlug': 'digital-outcomes-and-specialists-2'
-                },
-                'status': 'submitted',
-            },
-            {
-                'briefId': 5,
-                'brief': {
-                    'title': 'Withdrawn opportunity',
-                    'applicationsClosedAt': '2017-06-05T10:26:21.538917Z',
-                    'status': 'withdrawn',
-                    'frameworkSlug': 'digital-outcomes-and-specialists-2'
-                },
-                'status': 'submitted',
-            },
-            {
-                'briefId': 6,
-                'brief': {
-                    'title': 'Opportunity awarded to this brief response',
-                    'applicationsClosedAt': '2017-06-04T10:26:21.538917Z',
-                    'status': 'awarded',
-                    'frameworkSlug': 'digital-outcomes-and-specialists-2'
-                },
-                'status': 'awarded',
-            },
-            {
-                'briefId': 7,
-                'brief': {
-                    'title': 'Opportunity awarded to a different brief response',
-                    'applicationsClosedAt': '2017-06-03T10:26:21.538917Z',
-                    'status': 'awarded',
-                    'frameworkSlug': 'digital-outcomes-and-specialists-2'
-                },
-                'status': 'submitted',
-            },
-            {
-                'briefId': 8,
-                'brief': {
-                    'title': 'Opportunity pending awarded to this brief response - it should look submitted though',
-                    'applicationsClosedAt': '2017-06-02T10:26:21.538917Z',
-                    'status': 'closed',
-                    'frameworkSlug': 'digital-outcomes-and-specialists-2'
-                },
-                'status': 'pending-awarded',
-            },
-            {
-                'briefId': 9,
-                'brief': {
-                    'title': 'Opportunity pending awarded to this brief response but was then cancelled instead',
-                    'applicationsClosedAt': '2017-06-01T10:26:21.538917Z',
-                    'status': 'cancelled',
-                    'frameworkSlug': 'digital-outcomes-and-specialists-2'
-                },
-                'status': 'pending-awarded',
-            },
-        ]}
+            ]
+        }
         rows = self.get_table_rows_by_id('submitted-opportunities', data_api_client)
-        statuses = [row.getchildren()[2].text_content().strip() for row in rows]
+        return [row.getchildren()[2].text_content().strip() for row in rows][0]
 
-        assert statuses[0] == 'Submitted'
-        assert statuses[1] == 'Submitted'
-        assert statuses[2] == 'Opportunity cancelled'
-        assert statuses[3] == 'Not won'
-        assert statuses[4] == 'Opportunity withdrawn'
-        assert statuses[5] == 'Won'
-        assert statuses[6] == 'Not won'
-        assert statuses[7] == 'Submitted'
-        assert statuses[8] == 'Opportunity cancelled'
+    def test_submitted_brief_response_for_open_brief_shows_submitted_status(self, data_api_client):
+        assert self._get_brief_response_dashboard_status(data_api_client, "submitted", "live") == "Submitted"
+
+    def test_submitted_brief_response_for_closed_brief_shows_submitted_status(self, data_api_client):
+        assert self._get_brief_response_dashboard_status(data_api_client, "submitted", "closed") == "Submitted"
+
+    def test_submitted_brief_response_for_cancelled_brief_shows_cancelled_status(self, data_api_client):
+        assert self._get_brief_response_dashboard_status(
+            data_api_client, "submitted", "cancelled") == "Opportunity cancelled"
+
+    def test_submitted_brief_response_for_unsuccessful_brief_shows_not_won_status(self, data_api_client):
+        assert self._get_brief_response_dashboard_status(data_api_client, "submitted", "unsuccessful") == "Not won"
+
+    def test_submitted_brief_response_for_withdrawn_brief_shows_withdrawn_status(self, data_api_client):
+        assert self._get_brief_response_dashboard_status(
+            data_api_client, "submitted", "withdrawn") == "Opportunity withdrawn"
+
+    def test_brief_awarded_to_different_brief_response_shows_not_won_status(self, data_api_client):
+        assert self._get_brief_response_dashboard_status(data_api_client, "submitted", "awarded") == "Not won"
+
+    def test_pending_award_brief_response_for_closed_brief_shows_submitted_status(self, data_api_client):
+        assert self._get_brief_response_dashboard_status(data_api_client, "pending-awarded", "closed") == "Submitted"
+
+    def test_pending_award_brief_response_for_cancelled_brief_shows_not_won_status(self, data_api_client):
+        assert self._get_brief_response_dashboard_status(
+            data_api_client, "pending-awarded", "cancelled") == "Opportunity cancelled"
+
+    def test_awarded_brief_response_shows_won_status(self, data_api_client):
+        assert self._get_brief_response_dashboard_status(data_api_client, "awarded", "awarded") == "Won"

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -136,3 +136,109 @@ class TestOpportunitiesDashboard(BaseApplicationTest):
         assert 'Highest date' in first_row.text_content()
         assert 'Mid date' in second_row.text_content()
         assert 'Lowest date' in third_row.text_content()
+
+    def test_completed_list_of_opportunities_gives_correct_status_for_each_application(self, data_api_client):
+        self.find_brief_responses_response = {'briefResponses': [
+            {
+                'briefId': 1,
+                'brief': {
+                    'title': 'Submitted brief response for open opportunity',
+                    'applicationsClosedAt': '2017-06-09T10:26:21.538917Z',
+                    'status': 'live',
+                    'frameworkSlug': 'digital-outcomes-and-specialists-2'
+                },
+                'status': 'submitted',
+            },
+            {
+                'briefId': 2,
+                'brief': {
+                    'title': 'Submitted brief response for closed brief',
+                    'applicationsClosedAt': '2017-06-08T10:26:21.538917Z',
+                    'status': 'closed',
+                    'frameworkSlug': 'digital-outcomes-and-specialists-2'
+                },
+                'status': 'submitted',
+            },
+            {
+                'briefId': 3,
+                'brief': {
+                    'title': 'Cancelled opportunity',
+                    'applicationsClosedAt': '2017-06-07T10:26:21.538917Z',
+                    'status': 'cancelled',
+                    'frameworkSlug': 'digital-outcomes-and-specialists-2'
+                },
+                'status': 'submitted',
+            },
+            {
+                'briefId': 4,
+                'brief': {
+                    'title': 'Unsuccessful opportunity',
+                    'applicationsClosedAt': '2017-06-06T10:26:21.538917Z',
+                    'status': 'unsuccessful',
+                    'frameworkSlug': 'digital-outcomes-and-specialists-2'
+                },
+                'status': 'submitted',
+            },
+            {
+                'briefId': 5,
+                'brief': {
+                    'title': 'Withdrawn opportunity',
+                    'applicationsClosedAt': '2017-06-05T10:26:21.538917Z',
+                    'status': 'withdrawn',
+                    'frameworkSlug': 'digital-outcomes-and-specialists-2'
+                },
+                'status': 'submitted',
+            },
+            {
+                'briefId': 6,
+                'brief': {
+                    'title': 'Opportunity awarded to this brief response',
+                    'applicationsClosedAt': '2017-06-04T10:26:21.538917Z',
+                    'status': 'awarded',
+                    'frameworkSlug': 'digital-outcomes-and-specialists-2'
+                },
+                'status': 'awarded',
+            },
+            {
+                'briefId': 7,
+                'brief': {
+                    'title': 'Opportunity awarded to a different brief response',
+                    'applicationsClosedAt': '2017-06-03T10:26:21.538917Z',
+                    'status': 'awarded',
+                    'frameworkSlug': 'digital-outcomes-and-specialists-2'
+                },
+                'status': 'submitted',
+            },
+            {
+                'briefId': 8,
+                'brief': {
+                    'title': 'Opportunity pending awarded to this brief response - it should look submitted though',
+                    'applicationsClosedAt': '2017-06-02T10:26:21.538917Z',
+                    'status': 'closed',
+                    'frameworkSlug': 'digital-outcomes-and-specialists-2'
+                },
+                'status': 'pending-awarded',
+            },
+            {
+                'briefId': 9,
+                'brief': {
+                    'title': 'Opportunity pending awarded to this brief response but was then cancelled instead',
+                    'applicationsClosedAt': '2017-06-01T10:26:21.538917Z',
+                    'status': 'cancelled',
+                    'frameworkSlug': 'digital-outcomes-and-specialists-2'
+                },
+                'status': 'pending-awarded',
+            },
+        ]}
+        rows = self.get_table_rows_by_id('submitted-opportunities', data_api_client)
+        statuses = [row.getchildren()[2].text_content().strip() for row in rows]
+
+        assert statuses[0] == 'Submitted'
+        assert statuses[1] == 'Submitted'
+        assert statuses[2] == 'Opportunity cancelled'
+        assert statuses[3] == 'Not won'
+        assert statuses[4] == 'Opportunity withdrawn'
+        assert statuses[5] == 'Won'
+        assert statuses[6] == 'Not won'
+        assert statuses[7] == 'Submitted'
+        assert statuses[8] == 'Opportunity cancelled'


### PR DESCRIPTION
https://trello.com/c/T6AICSmb/711-2-update-supplier-response-page-and-dashboard-based-on-brief-status

Reviewers: My commits are pretty tidy, you may find it easier to review commit by commit

### Summary
- show application status on dashboard
- don't show 'what to do next' content on view your brief response page if the outcome of the brief is known
- add link to view the opportunity (and outcome)
- no longer show persistent flash messages on the view your response page
- Change breadcrumbs on the view your response page to point back to the applications overview page rather than the list of DOS opportunities

### Opportunity dashboard
![image](https://user-images.githubusercontent.com/7228605/30122335-f77ccdee-9325-11e7-9a6a-92d5265d031b.png)

### Awarded brief
An example of when the outcome of the brief is known
![image](https://user-images.githubusercontent.com/7228605/30335181-894c4472-97d9-11e7-88b1-7b780c9fbda1.png)


### Closed brief
An example of when the outcome of the brief is not known
![image](https://user-images.githubusercontent.com/7228605/30335213-9faa849a-97d9-11e7-86d3-46ee330e9ddd.png)

### Successful application to a legacy brief
![image](https://user-images.githubusercontent.com/7228605/30335456-578cdcfc-97da-11e7-87eb-ae3a6a20e9f3.png)

### Unsuccessful application to a legacy brief
An example of when one of our legacy briefs which has an unsuccessful application (they unsuccessful if they answer one of the essential requirements as False)
![image](https://user-images.githubusercontent.com/7228605/30335310-e2287f8e-97d9-11e7-8621-9fb99fd16f8d.png)




