### PR TITLE
Remove code related to migration period of new supplier flow

### DIFF
--- a/app/main/helpers/__init__.py
+++ b/app/main/helpers/__init__.py
@@ -23,10 +23,3 @@ def login_required(func):
             return current_app.login_manager.unauthorized()
         return func(*args, **kwargs)
     return decorated_view
-
-
-def new_supplier_flow_active_for_datetime(dt):
-    if not current_app.config['FEATURE_FLAGS_NEW_SUPPLIER_FLOW']:
-        return False
-    nsf_on = datetime.strptime(current_app.config['FEATURE_FLAGS_NEW_SUPPLIER_FLOW'], "%Y-%m-%d")
-    return nsf_on <= dt

--- a/config.py
+++ b/config.py
@@ -2,7 +2,7 @@
 
 import os
 import jinja2
-from dmutils.status import enabled_since, get_version_label
+from dmutils.status import get_version_label
 from dmutils.asset_fingerprint import AssetFingerprinter
 
 
@@ -43,8 +43,6 @@ class Config(object):
     # Feature Flags
     RAISE_ERROR_ON_MISSING_FEATURES = True
 
-    FEATURE_FLAGS_NEW_SUPPLIER_FLOW = False
-
     # Logging
     DM_LOG_LEVEL = 'DEBUG'
     DM_PLAIN_TEXT_LOGS = False
@@ -71,8 +69,6 @@ class Test(Config):
     DM_MANDRILL_API_KEY = 'MANDRILL'
     SECRET_KEY = 'verySecretKey'
 
-    FEATURE_FLAGS_NEW_SUPPLIER_FLOW = enabled_since('2016-11-29')
-
     DM_DATA_API_AUTH_TOKEN = 'myToken'
 
 
@@ -80,9 +76,6 @@ class Development(Config):
     DEBUG = True
     DM_PLAIN_TEXT_LOGS = True
     SESSION_COOKIE_SECURE = False
-
-    # Dates not formatted like YYYY-(0)M-(0)D will fail
-    FEATURE_FLAGS_NEW_SUPPLIER_FLOW = enabled_since('2016-11-29')
 
     DM_DATA_API_URL = "http://localhost:5000"
     DM_DATA_API_AUTH_TOKEN = "myToken"
@@ -100,16 +93,15 @@ class Live(Config):
 
 
 class Preview(Live):
-    FEATURE_FLAGS_NEW_SUPPLIER_FLOW = enabled_since('2017-02-06')
+    pass
 
 
 class Production(Live):
-    FEATURE_FLAGS_NEW_SUPPLIER_FLOW = enabled_since('2017-02-08')
+    pass
 
 
 class Staging(Production):
-    FEATURE_FLAGS_NEW_SUPPLIER_FLOW = enabled_since('2017-02-07')
-
+    pass
 
 configs = {
     'development': Development,


### PR DESCRIPTION
The code removed was not tidyed up after the new supplier flow for
applying to a brief was released and given two weeks to allow all
'old style' or 'legacy' briefs to finish their `live` period.

Now we have no more 'old style' briefs that are live, we do not
need to do these additional checks as they will never be false.