### PR TITLE
Change from flake8-putty to per-file-ignores

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -9,7 +9,8 @@ exclude = venv*,__pycache__,node_modules,bower_components
 ignore = D203,W503
 max-complexity = 7
 max-line-length = 120
-putty-ignore =
-    **/__init__.py : +F401
-    app/__init__.py, app/main/__init__.py, app/status/__init__.py : +E402
-    app/main/views/*.py : +C901
+per-file-ignores =
+    **/__init__.py : F401
+    app/main/__init__.py : E402
+    app/status/__init__.py : E402
+    app/main/views/*.py : C901

--- a/config.py
+++ b/config.py
@@ -103,6 +103,7 @@ class Production(Live):
 class Staging(Production):
     pass
 
+
 configs = {
     'development': Development,
     'preview': Preview,

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,8 +1,8 @@
 -r requirements.txt
 coverage==3.7.1
 cssselect==0.9.1
-flake8==2.6.2
-flake8-putty==0.4.0
+flake8==3.5.0
+flake8-per-file-ignores==0.4.0
 freezegun==0.3.4
 lxml==3.8.0
 mock==2.0.0


### PR DESCRIPTION
## Summary
Add flake8 per-file-ignores, in place of flake8-putty, so that we can support newer Python3 syntax like eg f-strings and type annotations.

Flake8 report:
```
/Users/samuelwilliams/git/digitalmarketplace-brief-responses-frontend/venv/bin/flake8 .
./config.py:106:1: E305 expected 2 blank lines after class or function definition, found 1
./app/__init__.py:0:1: X100 Superfluous per-file-ignores for E402
make: *** [test-flake8] Error 1
```