### PR TITLE
Change heading copy for brief responses application

### DIFF
--- a/app/templates/briefs/check_your_answers.html
+++ b/app/templates/briefs/check_your_answers.html
@@ -59,7 +59,7 @@
 <div class="grid-row">
   <div class="column-two-thirds">
     {% with
-      heading = "Check your answers" if brief_response.status == 'draft' else "Your application for ‘{}’".format(brief.title),
+      heading = "Check and submit your answers" if brief_response.status == 'draft' else "Your application for ‘{}’".format(brief.title),
       smaller = true
       %}
         {% include 'toolkit/page-heading.html' %}

--- a/tests/app/main/test_briefs.py
+++ b/tests/app/main/test_briefs.py
@@ -1278,7 +1278,7 @@ class TestCheckYourAnswers(BaseApplicationTest):
 
         page_title = doc.xpath("//main//*//h1//text()")[0].strip()
         if brief_response_status == "draft":
-            assert page_title == "Check your answers"
+            assert page_title == "Check and submit your answers"
         else:
             assert page_title == "Your application for ‘I need a thing to do a thing’"
 


### PR DESCRIPTION
Since we changed the application journey we have had several suppliers who failed to submit an application in time because they did not realise that their application had not been submitted at the point of reaching the check your answers page.

After reviewing what the suppliers told us we believe that they are looking at the content on the page but they just did not realise they still needed to perform an action.

We are proposing this small content change which has been signed off by Jane and will monitor wether we continue to receive support queries.

Before:
<img width="1042" alt="screen shot 2017-12-13 at 14 17 26" src="https://user-images.githubusercontent.com/3798032/33943222-6188f0e6-e010-11e7-8444-e9bb85456663.png">

After:
<img width="1057" alt="screen shot 2017-12-13 at 14 00 19" src="https://user-images.githubusercontent.com/3798032/33943158-31a5401e-e010-11e7-9f31-1c265064a5e5.png">