### PR TITLE
Update gulp-include

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -4,24 +4,24 @@
   Sprockets-style (https://github.com/sstephenson/sprockets)
   directives to concatenate multiple Javascript files into one.
 */
-//= include ../../../node_modules/govuk_frontend_toolkit/javascripts/vendor/polyfills/bind.js
-//= include _details.polyfill.js
+//= require ../../../node_modules/govuk_frontend_toolkit/javascripts/vendor/polyfills/bind.js
+//= require _details.polyfill.js
 
-//= include ../../../node_modules/jquery/dist/jquery.js
-//= include ../../../node_modules/hogan/web/builds/3.0.2/hogan-3.0.2.js
-//= include ../../../node_modules/digitalmarketplace-frontend-toolkit/toolkit/javascripts/list-entry.js
-//= include ../../../node_modules/digitalmarketplace-frontend-toolkit/toolkit/javascripts/word-counter.js
-//= include ../../../node_modules/digitalmarketplace-frontend-toolkit/toolkit/javascripts/validation.js
-//= include ../../../node_modules/govuk_frontend_toolkit/javascripts/govuk/selection-buttons.js
-//= include ../../../node_modules/govuk_frontend_toolkit/javascripts/govuk/shim-links-with-button-role.js
-//= include ../../../node_modules/govuk_frontend_toolkit/javascripts/govuk/stick-at-top-when-scrolling.js
-//= include ../../../node_modules/govuk_frontend_toolkit/javascripts/govuk/stop-scrolling-at-footer.js
-//= include ../../../node_modules/digitalmarketplace-frontend-toolkit/toolkit/javascripts/shim-links-with-button-role.js
-//= include ../../../node_modules/digitalmarketplace-frontend-toolkit/toolkit/javascripts/show-hide-content.js
-//= include _analytics.js
-//= include _selection-buttons.js
-//= include _stick-at-top-when-scrolling.js
-//= include category-picker.js
+//= require ../../../node_modules/jquery/dist/jquery.js
+//= require ../../../node_modules/hogan.js/web/builds/3.0.2/hogan-3.0.2.js
+//= require ../../../node_modules/digitalmarketplace-frontend-toolkit/toolkit/javascripts/list-entry.js
+//= require ../../../node_modules/digitalmarketplace-frontend-toolkit/toolkit/javascripts/word-counter.js
+//= require ../../../node_modules/digitalmarketplace-frontend-toolkit/toolkit/javascripts/validation.js
+//= require ../../../node_modules/govuk_frontend_toolkit/javascripts/govuk/selection-buttons.js
+//= require ../../../node_modules/govuk_frontend_toolkit/javascripts/govuk/shim-links-with-button-role.js
+//= require ../../../node_modules/govuk_frontend_toolkit/javascripts/govuk/stick-at-top-when-scrolling.js
+//= require ../../../node_modules/govuk_frontend_toolkit/javascripts/govuk/stop-scrolling-at-footer.js
+//= require ../../../node_modules/digitalmarketplace-frontend-toolkit/toolkit/javascripts/shim-links-with-button-role.js
+//= require ../../../node_modules/digitalmarketplace-frontend-toolkit/toolkit/javascripts/show-hide-content.js
+//= require _analytics.js
+//= require _selection-buttons.js
+//= require _stick-at-top-when-scrolling.js
+//= require category-picker.js
 
 (function(GOVUK, GDM) {
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "govuk-elements-sass": "3.0.3",
     "gulp": "3.8.11",
     "gulp-filelog": "0.4.1",
-    "gulp-include": "2.0.0",
+    "gulp-include": "2.3.1",
     "gulp-sass": "3.1.0",
     "gulp-shell": "0.2.9",
     "gulp-uglify": "1.5.1",
@@ -19,7 +19,7 @@
     "colors": "1.1.2",
     "jquery": "1.12.0",
     "hogan.js": "3.0.2",
-    "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v24.6.0",
+    "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v27.0.0",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.19.2/jinja_govuk_template-0.19.2.tgz",
     "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#9.2.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -57,10 +57,6 @@ aproba@^1.0.3:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/aproba/-/aproba-1.2.0.tgz#6802e6264efd18c790a1b0d517f0f2627bf2c94a"
 
-archy@^0.0.2:
-  version "0.0.2"
-  resolved "https://registry.yarnpkg.com/archy/-/archy-0.0.2.tgz#910f43bf66141fc335564597abc189df44b3d35e"
-
 archy@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/archy/-/archy-1.0.0.tgz#f9c8c13757cc1dd7bc379ac77b2c62a5c2868c40"
@@ -256,16 +252,6 @@ cache-base@^1.0.1:
     to-object-path "^0.3.0"
     union-value "^1.0.0"
     unset-value "^1.0.0"
-
-caller-path@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/caller-path/-/caller-path-0.1.0.tgz#94085ef63581ecd3daa92444a8fe94e82577751f"
-  dependencies:
-    callsites "^0.2.0"
-
-callsites@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/callsites/-/callsites-0.2.0.tgz#afab96262910a7f33c19a5775825c69f34e350ca"
 
 camelcase-keys@^2.0.0:
   version "2.1.0"
@@ -537,15 +523,15 @@ detect-file@^1.0.0:
   version "0.0.0"
   resolved "https://github.com/alphagov/digitalmarketplace-frameworks.git#277c960596a64f296682306860ca9403748b6e60"
 
-"digitalmarketplace-frontend-toolkit@https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v24.6.0":
+"digitalmarketplace-frontend-toolkit@https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v27.0.0":
   version "0.0.1"
-  resolved "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#5ae29f5d6b6e375f0125c87b325a4efb80c4b5af"
+  resolved "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#bec67d8d44fa0f279be32786e7fb75a6e1981629"
   dependencies:
     del "^2.2.2"
     govuk-elements-sass "3.0.3"
     govuk_frontend_toolkit "5.0.3"
-    gulp "3.8.7"
-    gulp-jasmine-phantom "2.0.1"
+    gulp "3.8.11"
+    gulp-jasmine-phantom "3.0.0"
     jasmine-core "2.6.4"
 
 duplexer2@0.0.2:
@@ -637,10 +623,6 @@ extend@^3.0.0, extend@~3.0.0, extend@~3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.1.tgz#a755ea7bc1adfcc5a31ce7e762dbaadc5e636444"
 
-extend@~1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/extend/-/extend-1.3.0.tgz#d1516fb0ff5624d2ebf9123ea1dac5a1994004f8"
-
 extglob@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/extglob/-/extglob-2.0.2.tgz#3290f46208db1b2e8eb8be0c94ed9e6ad80edbe2"
@@ -706,13 +688,6 @@ findup-sync@^2.0.0:
     is-glob "^3.1.0"
     micromatch "^3.0.4"
     resolve-dir "^1.0.1"
-
-findup-sync@~0.1.2:
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/findup-sync/-/findup-sync-0.1.3.tgz#7f3e7a97b82392c653bf06589bd85190e93c3683"
-  dependencies:
-    glob "~3.2.9"
-    lodash "~2.4.1"
 
 fined@^1.0.1:
   version "1.1.0"
@@ -867,7 +842,7 @@ glob2base@^0.0.12:
   dependencies:
     find-index "^0.1.1"
 
-glob@^3.2.11, glob@~3.2.9:
+glob@^3.2.11:
   version "3.2.11"
   resolved "https://registry.yarnpkg.com/glob/-/glob-3.2.11.tgz#4a973f635b9190f715d10987d5c00fd2815ebe3d"
   dependencies:
@@ -1021,24 +996,16 @@ gulp-filelog@0.4.1:
     gulp-util "~3.0.1"
     through2 "*"
 
-gulp-include@2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/gulp-include/-/gulp-include-2.0.0.tgz#77afc979577024ca413c930a3eeb342cac4015b2"
+gulp-include@2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/gulp-include/-/gulp-include-2.3.1.tgz#f1e0ed3f0fd074c347c7e59f9cf038d3dbdb3e30"
   dependencies:
     event-stream "~3.1.0"
     glob "^5.0.12"
     gulp-util "~2.2.10"
-
-gulp-jasmine-phantom@2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/gulp-jasmine-phantom/-/gulp-jasmine-phantom-2.0.1.tgz#e9955704bab9697a96b8a6dbbd060d460d007edc"
-  dependencies:
-    glob "^4.0.6"
-    gulp-util "^3.0.0"
-    handlebars "^2.0.0"
-    minijasminenode2 dflynn15/minijasminenode
-    require-uncached "^1.0.2"
-    through2 "^0.6.1"
+    source-map "^0.5.1"
+    strip-bom "^2.0.0"
+    vinyl-sourcemaps-apply "^0.2.0"
 
 gulp-jasmine-phantom@3.0.0:
   version "3.0.0"
@@ -1145,23 +1112,6 @@ gulp@3.8.11:
     semver "^4.1.0"
     tildify "^1.0.0"
     v8flags "^2.0.2"
-    vinyl-fs "^0.3.0"
-
-gulp@3.8.7:
-  version "3.8.7"
-  resolved "https://registry.yarnpkg.com/gulp/-/gulp-3.8.7.tgz#187e5316d65aa5188de447b41b3c0ee9bf322be1"
-  dependencies:
-    archy "^0.0.2"
-    chalk "^0.5.0"
-    deprecated "^0.0.1"
-    gulp-util "^3.0.0"
-    interpret "^0.3.2"
-    liftoff "^0.12.0"
-    minimist "^0.2.0"
-    orchestrator "^0.3.0"
-    pretty-hrtime "^0.2.0"
-    semver "^3.0.1"
-    tildify "^0.2.0"
     vinyl-fs "^0.3.0"
 
 gulplog@^1.0.0:
@@ -1525,10 +1475,6 @@ isstream@~0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a"
 
-jasmine-core@2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/jasmine-core/-/jasmine-core-2.0.0.tgz#8c7b590f17e6583e42f41d710d12549e0d319929"
-
 jasmine-core@2.6.4:
   version "2.6.4"
   resolved "https://registry.yarnpkg.com/jasmine-core/-/jasmine-core-2.6.4.tgz#dec926cd0a9fa287fb6db5c755fa487e74cecac5"
@@ -1537,7 +1483,7 @@ jasmine-core@~2.4.0:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/jasmine-core/-/jasmine-core-2.4.1.tgz#6f83ab3a0f16951722ce07d206c773d57cc838be"
 
-"jasmine@github:dflynn15/jasmine-npm":
+jasmine@dflynn15/jasmine-npm:
   version "2.4.1"
   resolved "https://codeload.github.com/dflynn15/jasmine-npm/tar.gz/5f74e4336b247e67bbc509a8f82f3c4fa6b52964"
   dependencies:
@@ -1617,15 +1563,6 @@ lcid@^1.0.0:
   resolved "https://registry.yarnpkg.com/lcid/-/lcid-1.0.0.tgz#308accafa0bc483a3867b4b6f2b9506251d1b835"
   dependencies:
     invert-kv "^1.0.0"
-
-liftoff@^0.12.0:
-  version "0.12.1"
-  resolved "https://registry.yarnpkg.com/liftoff/-/liftoff-0.12.1.tgz#bcaa49759c68396b83b984ad0b2d8cc226f9526d"
-  dependencies:
-    extend "~1.3.0"
-    findup-sync "~0.1.2"
-    minimist "~0.2.0"
-    resolve "~0.7.0"
 
 liftoff@^2.0.1:
   version "2.5.0"
@@ -1939,12 +1876,6 @@ mime-types@^2.1.12, mime-types@~2.1.17, mime-types@~2.1.7:
   dependencies:
     mime-db "~1.30.0"
 
-"minijasminenode2@github:dflynn15/minijasminenode":
-  version "1.0.0"
-  resolved "https://codeload.github.com/dflynn15/minijasminenode/tar.gz/a001e549b8b141a7562a7ea21dec9a1df96f2527"
-  dependencies:
-    jasmine-core "2.0.0"
-
 minimatch@0.3:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-0.3.0.tgz#275d8edaac4f1bb3326472089e7949c8394699dd"
@@ -1975,7 +1906,7 @@ minimist@0.0.8:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
 
-minimist@^0.2.0, minimist@~0.2.0:
+minimist@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.2.0.tgz#4dffe525dae2b864c66c2e23c6271d7afdecefce"
 
@@ -2469,23 +2400,12 @@ require-main-filename@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-1.0.1.tgz#97f717b69d48784f5f526a6c5aa8ffdda055a4d1"
 
-require-uncached@^1.0.2:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/require-uncached/-/require-uncached-1.0.3.tgz#4e0d56d6c9662fd31e43011c4b95aa49955421d3"
-  dependencies:
-    caller-path "^0.1.0"
-    resolve-from "^1.0.0"
-
 resolve-dir@^1.0.0, resolve-dir@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/resolve-dir/-/resolve-dir-1.0.1.tgz#79a40644c362be82f26effe739c9bb5382046f43"
   dependencies:
     expand-tilde "^2.0.0"
     global-modules "^1.0.0"
-
-resolve-from@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-1.0.1.tgz#26cbfe935d1aeeeabb29bc3fe5aeb01e93d44226"
 
 resolve-url@^0.2.1:
   version "0.2.1"
@@ -2496,10 +2416,6 @@ resolve@^1.1.6, resolve@^1.1.7:
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.5.0.tgz#1f09acce796c9a762579f31b2c1cc4c3cddf9f36"
   dependencies:
     path-parse "^1.0.5"
-
-resolve@~0.7.0:
-  version "0.7.4"
-  resolved "https://registry.yarnpkg.com/resolve/-/resolve-0.7.4.tgz#395a9ef9e873fbfe12bd14408bd91bb936003d69"
 
 right-align@^0.1.1:
   version "0.1.3"
@@ -2536,10 +2452,6 @@ scss-tokenizer@^0.2.3:
 "semver@2 || 3 || 4 || 5":
   version "5.4.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.4.1.tgz#e059c09d8571f0540823733433505d3a2f00b18e"
-
-semver@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-3.0.1.tgz#720ac012515a252f91fb0dd2e99a56a70d6cf078"
 
 semver@^4.1.0:
   version "4.3.6"
@@ -2822,10 +2734,6 @@ through2@^0.6.1, through2@^0.6.3:
 through@2, through@~2.3, through@~2.3.1:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
-
-tildify@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/tildify/-/tildify-0.2.0.tgz#70e639947af67d6ab6b822bbed0a6806fd81e430"
 
 tildify@^1.0.0:
   version "1.2.0"


### PR DESCRIPTION
* Upgrade `gulp-include` from v2.0.0 to v2.3.1 as v2 fails to include jQuery correctly, breaking frontend-build.
* Upgrade `frontend-toolkit` to 27.0.0 to pull in shim-links correctly, identified missing by the updated gulp-include.
* Fix `hogan.js` import path
* Update `include` to `require`, which will only import the file a maximum of once.