### PR TITLE
Hard fail gulp include if import not found

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -124,7 +124,7 @@ gulp.task('sass', function () {
 gulp.task('js', function () {
   var stream = gulp.src(jsSourceFile)
     .pipe(filelog('Compressing JavaScript files'))
-    .pipe(include())
+    .pipe(include({'hardFail': true}))
     .pipe(sourcemaps.init())
     .pipe(uglify(
       uglifyOptions[environment]


### PR DESCRIPTION
## Summary
Gulp silently ignores missing imports without the 'hardFail' option. Let's add it to make sure that every file we want is actually imported.