### PR TITLE
Redirect malformed URL to public brief page

### DIFF
--- a/app/main/views/briefs.py
+++ b/app/main/views/briefs.py
@@ -333,6 +333,23 @@ def application_submitted(brief_id):
     )
 
 
+@main.route('/<int:brief_id>')
+def redirect_to_public_opportunity_page(brief_id):
+    """
+    The external URL for the public brief page is managed within the Buyer FE.
+    There is an edge case where a supplier may try to manipulate the URL from their
+    brief application flow to reach the public brief page, which never reaches the Buyer FE because of the
+    '/suppliers/opportunities/...' prefix, which nginx routes to the Brief Responses FE (here!).
+
+    This redirect replaces the 'suppliers' prefix with the correct framework name, which allows nginx to route
+    to the Buyer FE as expected, avoiding a NotImplemented 500 error.
+    """
+    brief = get_brief(data_api_client, brief_id)
+    return redirect(
+        url_for('external.get_brief_by_id', framework_framework=brief['frameworkFramework'], brief_id=brief_id)
+    )
+
+
 def _render_not_eligible_for_brief_error_page(brief, clarification_question=False):
     common_kwargs = {
         "supplier_id": current_user.supplier_id,


### PR DESCRIPTION
https://trello.com/c/fpNVMkMj/344-500-on-brief-responses-fe-at-suppliers-opportunities-brief

The external URL for the public brief page (`/digital-outcomes-and-specialists/opportunities/<brief_id>`) is managed within the Buyer FE.
There is an edge case where a supplier may try to manipulate the URL from their
brief application flow to reach the public brief page, which never reaches the Buyer FE because of the `/suppliers/opportunities/...` prefix, which nginx routes to the Brief Responses FE (here!).

It seems likely that the supplier is trying to reach the public brief page (there's no link for this on the result page following a successful brief response application, for example). 
The redirect replaces the 'suppliers' part of the prefix with the correct framework name, which allows nginx to route to the Buyer FE as expected, avoiding a NotImplemented 500 error.