### PR TITLE
Accessibility fixes for summary table Edit links

### DIFF
--- a/app/templates/briefs/_brief_response_data.html
+++ b/app/templates/briefs/_brief_response_data.html
@@ -29,7 +29,8 @@
                     analytics="trackEvent",
                     analytics_category="internal-link",
                     analytics_action="Edit Supplier Application",
-                    analytics_label=brief_response.status
+                    analytics_label=brief_response.status,
+                    hidden_text=section.name
                   )
                 }}
               {% endif %}
@@ -52,7 +53,8 @@
                     analytics="trackEvent",
                     analytics_category="internal-link",
                     analytics_action="Edit Supplier Application",
-                    analytics_label=brief_response.status
+                    analytics_label=brief_response.status,
+                    hidden_text=section.name
                   )
                 }}
               {% endif %}
@@ -98,7 +100,7 @@
                         data-analytics-category="internal-link"
                         data-analytics-action="Edit Supplier Application"
                         data-analytics-label="{{ brief_response.status }}"
-                      >Edit</a>
+                      >Edit<span class="visually-hidden"> {{ item.label }}</span></a>
                     {% endcall %}
                 {% endif %}
               {% endcall %}

--- a/tests/app/main/test_briefs.py
+++ b/tests/app/main/test_briefs.py
@@ -1264,7 +1264,7 @@ class TestCheckYourAnswers(BaseApplicationTest):
         )
         res = self.client.get('/suppliers/opportunities/1234/responses/5/application')
         doc = html.fromstring(res.get_data(as_text=True))
-        edit_application_links = [anchor.get('href') for anchor in doc.xpath('//a') if anchor.text_content() == 'Edit']
+        edit_application_links = [anchor.get('href') for anchor in doc.xpath('//a') if 'Edit' in anchor.text_content()]
         if edit_links_shown:
             assert edit_application_links == [
                 '/suppliers/opportunities/1234/responses/5/dayRate/edit',


### PR DESCRIPTION
Trello: https://trello.com/c/sYJYKnK9/58-how-summary-tables-handle-their-links-means-pages-can-contain-multiple-links-with-duplicate-text

The Check Your Answers summary page contains several Edit links. Screen reader users may find it difficult to distinguish between them:

![edit-links-check-your-answers](https://user-images.githubusercontent.com/3492540/36431932-d0f0048a-1650-11e8-9285-19a91aca65bf.png)

The `summary_table.top_link` macro in the frontend toolkit now has an additional `hidden_text` field  (as we currently do for the `edit_link` macro) which is rendered in a `<span class="visually-hidden"></span>` inside the link. 

We don't use the macro for edit links within a summary table, so the spans are hardcoded there. 

~~This can be merged once the FE toolkit PR is ready to pull in (Travis will fail on the yarn install step at the moment): https://github.com/alphagov/digitalmarketplace-frontend-toolkit/pull/406~~ Now ready to go.