### PR TITLE
Update import to import send_email from dm_mandrill

### DIFF
--- a/app/main/helpers/briefs.py
+++ b/app/main/helpers/briefs.py
@@ -6,7 +6,7 @@ from flask import abort, current_app, render_template
 from flask_login import current_user
 
 from dmapiclient.audit import AuditTypes
-from dmutils.email import send_email
+from dmutils.email.dm_mandrill import send_email
 from dmutils.email.exceptions import EmailError
 
 


### PR DESCRIPTION
Because we now have 3 different methods of sending emails we should update utils to ensure `send_email` is imported from the client specific sub-directory of `emails` in utils