### PR TITLE
Use centralised status method

### DIFF
--- a/app/status/views.py
+++ b/app/status/views.py
@@ -1,33 +1,12 @@
-from flask import jsonify, current_app, request
+from flask import request
 
 from . import status
 from .. import data_api_client
-from dmutils.status import get_flags
+from dmutils.status import get_app_status
 
 
 @status.route('/_status')
 def status():
-
-    if 'ignore-dependencies' in request.args:
-        return jsonify(
-            status="ok",
-        ), 200
-
-    api_status = data_api_client.get_status()
-    version = current_app.config['VERSION']
-
-    if api_status['status'] == "ok":
-        return jsonify(
-            status="ok",
-            version=version,
-            api_status=api_status,
-            flags=get_flags(current_app)
-        )
-
-    return jsonify(
-        status="error",
-        version=version,
-        api_status=api_status,
-        message="Error connecting to the (Data) API.",
-        flags=get_flags(current_app)
-    ), 500
+    return get_app_status(data_api_client=data_api_client,
+                          search_api_client=None,
+                          ignore_dependencies='ignore-dependencies' in request.args)

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -5,6 +5,6 @@ Flask==0.10.1
 Flask-Login==0.2.11
 Flask-WTF==0.12
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@34.1.1#egg=digitalmarketplace-utils==34.1.1
+git+https://github.com/alphagov/digitalmarketplace-utils.git@35.2.0#egg=digitalmarketplace-utils==35.2.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.2.0#egg=digitalmarketplace-content-loader==4.2.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@15.0.0#egg=digitalmarketplace-apiclient==15.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ Flask==0.10.1
 Flask-Login==0.2.11
 Flask-WTF==0.12
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@34.1.1#egg=digitalmarketplace-utils==34.1.1
+git+https://github.com/alphagov/digitalmarketplace-utils.git@35.2.0#egg=digitalmarketplace-utils==35.2.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.2.0#egg=digitalmarketplace-content-loader==4.2.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@15.0.0#egg=digitalmarketplace-apiclient==15.0.0
 


### PR DESCRIPTION
 ## Summary
The status endpoint for all of the apps is highly redundant across
repositories so I've moved it to dm-utils. We now only need to call this
method from the view stub in each app and pass in a couple of resources
(mainly the current_app and any api clients) to get a consistent status
JSON blob back.

 ## Ticket
https://trello.com/c/BBvu6eUk/383-ensure-healthcheck-endpoint-fails-if-low-disk-space