### PR TITLE
bump digitalmarketplace-utils dependency to 36.0.0, set DM_NOTIFY_REDIRECT_DOMAINS_TO_ADDRESS for `Live` configs

### DIFF
--- a/config.py
+++ b/config.py
@@ -90,6 +90,12 @@ class Live(Config):
     DM_LOG_PATH = '/var/log/digitalmarketplace/application.log'
     DM_HTTP_PROTO = 'https'
 
+    # use of invalid email addresses with live api keys annoys Notify
+    DM_NOTIFY_REDIRECT_DOMAINS_TO_ADDRESS = {
+        "example.com": "success@simulator.amazonses.com",
+        "example.gov.uk": "success@simulator.amazonses.com",
+    }
+
 
 class Preview(Live):
     pass

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -5,6 +5,6 @@ Flask==0.10.1
 Flask-Login==0.2.11
 Flask-WTF==0.12
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@35.2.0#egg=digitalmarketplace-utils==35.2.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@36.0.0#egg=digitalmarketplace-utils==36.0.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.2.0#egg=digitalmarketplace-content-loader==4.2.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@15.0.0#egg=digitalmarketplace-apiclient==15.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ Flask==0.10.1
 Flask-Login==0.2.11
 Flask-WTF==0.12
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@35.2.0#egg=digitalmarketplace-utils==35.2.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@36.0.0#egg=digitalmarketplace-utils==36.0.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.2.0#egg=digitalmarketplace-content-loader==4.2.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@15.0.0#egg=digitalmarketplace-apiclient==15.0.0
 
@@ -38,8 +38,8 @@ monotonic==0.3
 notifications-python-client==4.1.0
 odfpy==1.3.6
 pycparser==2.18
-PyJWT==1.6.0
-python-dateutil==2.7.0
+PyJWT==1.6.1
+python-dateutil==2.7.2
 python-json-logger==0.1.4
 pytz==2015.4
 PyYAML==3.11


### PR DESCRIPTION
Trello https://trello.com/c/YQB2HkiD/225-functional-tests-send-emails-to-invalid-email-addresses