### PR TITLE
Refactor test classes

### DIFF
--- a/tests/app/main/test_briefs.py
+++ b/tests/app/main/test_briefs.py
@@ -94,7 +94,6 @@ class TestBriefQuestionAndAnswerSession(BaseApplicationTest):
         super().setup_method(method)
         self.data_api_client_patch = mock.patch('app.main.views.briefs.data_api_client', autospec=True)
         self.data_api_client = self.data_api_client_patch.start()
-        self.login_as_buyer()
 
     def teardown_method(self, method):
         self.data_api_client_patch.stop()
@@ -162,7 +161,6 @@ class TestBriefClarificationQuestions(BaseApplicationTest):
         super().setup_method(method)
         self.data_api_client_patch = mock.patch('app.main.views.briefs.data_api_client', autospec=True)
         self.data_api_client = self.data_api_client_patch.start()
-        self.login_as_buyer()
 
     def teardown_method(self, method):
         self.data_api_client_patch.stop()
@@ -233,7 +231,6 @@ class TestSubmitClarificationQuestions(BaseApplicationTest):
         super().setup_method(method)
         self.data_api_client_patch = mock.patch('app.main.views.briefs.data_api_client', autospec=True)
         self.data_api_client = self.data_api_client_patch.start()
-        self.login_as_buyer()
 
     def teardown_method(self, method):
         self.data_api_client_patch.stop()
@@ -471,8 +468,7 @@ class TestApplyToBrief(BaseApplicationTest):
         self.data_api_client.get_framework.return_value = self.framework
         self.data_api_client.get_brief_response.return_value = self.brief_response()
 
-        with self.app.test_client():
-            self.login()
+        self.login()
 
     def teardown_method(self, method):
         super().teardown_method(method)
@@ -1291,8 +1287,7 @@ class TestCheckYourAnswers(BaseApplicationTest):
         )
         self.data_api_client.get_brief_response.return_value = self.brief_response()
 
-        with self.app.test_client():
-            self.login()
+        self.login()
 
     def teardown_method(self, method):
         super().teardown_method(method)
@@ -1670,9 +1665,7 @@ class TestStartBriefResponseApplication(BaseApplicationTest, BriefResponseTestHe
         self.data_api_client = self.data_api_client_patch.start()
         self.brief = api_stubs.brief(status='live', lot_slug='digital-specialists')
         self.brief['briefs']['publishedAt'] = '2016-12-25T12:00:00.000000Z'
-
-        with self.app.test_client():
-            self.login()
+        self.login()
 
     def teardown_method(self, method):
         self.data_api_client_patch.stop()
@@ -1682,8 +1675,6 @@ class TestStartBriefResponseApplication(BaseApplicationTest, BriefResponseTestHe
         self.brief = api_stubs.brief(status='closed', lot_slug='digital-specialists')
         self.brief['briefs']['publishedAt'] = '2016-12-25T12:00:00.000000Z'
         self.data_api_client.get_brief.return_value = self.brief
-        with self.app.test_client():
-            self.login()
 
         res = self.client.get('/suppliers/opportunities/1234/responses/start')
 
@@ -1829,9 +1820,7 @@ class TestPostStartBriefResponseApplication(BaseApplicationTest):
         self.data_api_client = self.data_api_client_patch.start()
         self.brief = api_stubs.brief(status='live', lot_slug='digital-specialists')
         self.brief['briefs']['publishedAt'] = '2016-12-25T12:00:00.000000Z'
-
-        with self.app.test_client():
-            self.login()
+        self.login()
 
     def teardown_method(self, method):
         self.data_api_client_patch.stop()
@@ -1926,8 +1915,7 @@ class TestResponseResultPage(BaseApplicationTest, BriefResponseTestHelpers):
                 }
             ]
         }
-        with self.app.test_client():
-            self.login()
+        self.login()
 
     def teardown_method(self, method):
         self.data_api_client_patch.stop()

--- a/tests/app/main/test_briefs.py
+++ b/tests/app/main/test_briefs.py
@@ -103,6 +103,7 @@ class TestBriefQuestionAndAnswerSession(BaseApplicationTest):
         res = self.client.get('/suppliers/opportunities/1/question-and-answer-session')
         assert res.status_code == 302
         assert '/login' in res.headers['Location']
+        self.assert_no_flashes()
 
     def test_q_and_a_session_details_shows_flash_error_message_if_user_is_not_a_supplier(self):
         self.login_as_buyer()

--- a/tests/app/main/test_briefs.py
+++ b/tests/app/main/test_briefs.py
@@ -450,7 +450,7 @@ class TestApplyToBrief(BaseApplicationTest):
     """Tests requests for the multipage flow for applying for a brief"""
 
     def setup_method(self, method):
-        super(TestApplyToBrief, self).setup_method(method)
+        super().setup_method(method)
 
         self.brief = api_stubs.brief(status='live', lot_slug='digital-specialists')
         self.brief['briefs']['essentialRequirements'] = ['Essential one', 'Essential two', 'Essential three']
@@ -475,7 +475,7 @@ class TestApplyToBrief(BaseApplicationTest):
             self.login()
 
     def teardown_method(self, method):
-        super(TestApplyToBrief, self).teardown_method(method)
+        super().teardown_method(method)
         self.data_api_client_patch.stop()
 
     @mock.patch("app.main.views.briefs.content_loader")
@@ -1275,7 +1275,7 @@ class TestApplyToBrief(BaseApplicationTest):
 class TestCheckYourAnswers(BaseApplicationTest):
 
     def setup_method(self, method):
-        super(TestCheckYourAnswers, self).setup_method(method)
+        super().setup_method(method)
 
         self.brief = api_stubs.brief(status='live', lot_slug='digital-specialists')
         self.brief['briefs']['essentialRequirements'] = ['Essential one', 'Essential two', 'Essential three']
@@ -1295,7 +1295,7 @@ class TestCheckYourAnswers(BaseApplicationTest):
             self.login()
 
     def teardown_method(self, method):
-        super(TestCheckYourAnswers, self).teardown_method(method)
+        super().teardown_method(method)
         self.data_api_client_patch.stop()
 
     @pytest.mark.parametrize('brief_response_status', ['draft', 'submitted'])

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -10,6 +10,9 @@ class TestOpportunitiesDashboard(BaseApplicationTest):
 
     def setup_method(self, method):
         super().setup_method(method)
+        self.data_api_client_patch = mock.patch('app.main.views.frameworks.data_api_client', autospec=True)
+        self.data_api_client = self.data_api_client_patch.start()
+
         self.framework_response = {
             'frameworks': {
                 'slug': 'digital-outcomes-and-specialists-2',
@@ -54,10 +57,7 @@ class TestOpportunitiesDashboard(BaseApplicationTest):
                 'status': 'submitted',
             }
         ]}
-
-        self.data_api_client_patch = mock.patch('app.main.views.frameworks.data_api_client', autospec=True)
-        self.data_api_client = self.data_api_client_patch.start()
-        self.login_as_buyer()
+        self.login()
 
     def teardown_method(self, method):
         self.data_api_client_patch.stop()

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -68,56 +68,51 @@ class TestOpportunitiesDashboard(BaseApplicationTest):
         self.data_api_client.get_framework.return_value = self.framework_response
         self.data_api_client.get_supplier_framework_info.return_value = self.supplier_framework_response
         self.data_api_client.find_brief_responses.return_value = self.find_brief_responses_response
-        with self.client:
-            self.login()
-            res = self.client.get(self.opportunities_dashboard_url)
 
-            assert res.status_code == 200
+        res = self.client.get(self.opportunities_dashboard_url)
 
-            doc = html.fromstring(res.get_data(as_text=True))
-            xpath_string = ".//*[@id='{}']/following-sibling::table[1]".format(table_id)
-            table = doc.xpath(xpath_string)[0]
-            rows = table.find_class('summary-item-row')
-            return rows
+        assert res.status_code == 200
+
+        doc = html.fromstring(res.get_data(as_text=True))
+        xpath_string = ".//*[@id='{}']/following-sibling::table[1]".format(table_id)
+        table = doc.xpath(xpath_string)[0]
+        rows = table.find_class('summary-item-row')
+        return rows
 
     def test_request_works_and_correct_data_is_fetched(self):
         self.data_api_client.get_supplier_framework_info.return_value = self.supplier_framework_response
         self.data_api_client.get_framework.return_value = self.framework_response
-        with self.client:
-            self.login()
-            resp = self.client.get(self.opportunities_dashboard_url)
-            assert resp.status_code == 200
-            self.data_api_client.find_brief_responses.assert_called_once_with(
-                supplier_id=1234,
-                framework='digital-outcomes-and-specialists-2'
-            )
+
+        resp = self.client.get(self.opportunities_dashboard_url)
+        assert resp.status_code == 200
+        self.data_api_client.find_brief_responses.assert_called_once_with(
+            supplier_id=1234,
+            framework='digital-outcomes-and-specialists-2'
+        )
 
     def test_404_if_framework_does_not_exist(self):
         self.data_api_client.get_framework.side_effect = APIError(mock.Mock(status_code=404))
-        with self.client:
-            self.login()
-            resp = self.client.get('/suppliers/frameworks/does-not-exist/opportunities')
 
-            assert resp.status_code == 404
+        resp = self.client.get('/suppliers/frameworks/does-not-exist/opportunities')
+
+        assert resp.status_code == 404
 
     def test_404_if_supplier_framework_does_not_exist(self):
         self.data_api_client.get_framework.return_value = self.framework_response
         self.data_api_client.get_supplier_framework_info.side_effect = APIError(mock.Mock(status_code=404))
-        with self.client:
-            self.login()
-            resp = self.client.get(self.opportunities_dashboard_url)
 
-            assert resp.status_code == 404
+        resp = self.client.get(self.opportunities_dashboard_url)
+
+        assert resp.status_code == 404
 
     def test_404_if_framework_is_not_dos(self):
         self.framework_response['frameworks'].update({'slug': 'g-cloud-9', 'framework': 'g-cloud'})
         self.data_api_client.get_framework.return_value = self.framework_response
         self.data_api_client.get_supplier_framework_info.return_value = self.supplier_framework_response
-        with self.client:
-            self.login()
-            resp = self.client.get('/suppliers/frameworks/g-cloud-9/opportunities')
 
-            assert resp.status_code == 404
+        resp = self.client.get('/suppliers/frameworks/g-cloud-9/opportunities')
+
+        assert resp.status_code == 404
 
     def test_404_if_supplier_not_on_framework(self):
         self.data_api_client.get_framework.return_value = self.framework_response
@@ -125,11 +120,10 @@ class TestOpportunitiesDashboard(BaseApplicationTest):
             {'onFramework': False}
         )
         self.data_api_client.get_supplier_framework_info.return_value = self.supplier_framework_response
-        with self.client:
-            self.login()
-            resp = self.client.get(self.opportunities_dashboard_url)
 
-            assert resp.status_code == 404
+        resp = self.client.get(self.opportunities_dashboard_url)
+
+        assert resp.status_code == 404
 
     def test_completed_list_of_opportunities(self):
         """Assert the 'Completed opportunities' table on this page contains the correct values."""

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -5,12 +5,11 @@ from dmapiclient import APIError
 from ..helpers import BaseApplicationTest
 
 
-@mock.patch('app.main.views.frameworks.data_api_client', autospec=True)
 class TestOpportunitiesDashboard(BaseApplicationTest):
     opportunities_dashboard_url = '/suppliers/opportunities/frameworks/digital-outcomes-and-specialists-2'
 
     def setup_method(self, method):
-        super(TestOpportunitiesDashboard, self).setup_method(method)
+        super().setup_method(method)
         self.framework_response = {
             'frameworks': {
                 'slug': 'digital-outcomes-and-specialists-2',
@@ -56,11 +55,19 @@ class TestOpportunitiesDashboard(BaseApplicationTest):
             }
         ]}
 
-    def get_table_rows_by_id(self, table_id, data_api_client):
+        self.data_api_client_patch = mock.patch('app.main.views.frameworks.data_api_client', autospec=True)
+        self.data_api_client = self.data_api_client_patch.start()
+        self.login_as_buyer()
+
+    def teardown_method(self, method):
+        self.data_api_client_patch.stop()
+        super().teardown_method(method)
+
+    def get_table_rows_by_id(self, table_id):
         """Helper function to get our 3 table rows as strings."""
-        data_api_client.get_framework.return_value = self.framework_response
-        data_api_client.get_supplier_framework_info.return_value = self.supplier_framework_response
-        data_api_client.find_brief_responses.return_value = self.find_brief_responses_response
+        self.data_api_client.get_framework.return_value = self.framework_response
+        self.data_api_client.get_supplier_framework_info.return_value = self.supplier_framework_response
+        self.data_api_client.find_brief_responses.return_value = self.find_brief_responses_response
         with self.client:
             self.login()
             res = self.client.get(self.opportunities_dashboard_url)
@@ -73,74 +80,74 @@ class TestOpportunitiesDashboard(BaseApplicationTest):
             rows = table.find_class('summary-item-row')
             return rows
 
-    def test_request_works_and_correct_data_is_fetched(self, data_api_client):
-        data_api_client.get_supplier_framework_info.return_value = self.supplier_framework_response
-        data_api_client.get_framework.return_value = self.framework_response
+    def test_request_works_and_correct_data_is_fetched(self):
+        self.data_api_client.get_supplier_framework_info.return_value = self.supplier_framework_response
+        self.data_api_client.get_framework.return_value = self.framework_response
         with self.client:
             self.login()
             resp = self.client.get(self.opportunities_dashboard_url)
             assert resp.status_code == 200
-            data_api_client.find_brief_responses.assert_called_once_with(
+            self.data_api_client.find_brief_responses.assert_called_once_with(
                 supplier_id=1234,
                 framework='digital-outcomes-and-specialists-2'
             )
 
-    def test_404_if_framework_does_not_exist(self, data_api_client):
-        data_api_client.get_framework.side_effect = APIError(mock.Mock(status_code=404))
+    def test_404_if_framework_does_not_exist(self):
+        self.data_api_client.get_framework.side_effect = APIError(mock.Mock(status_code=404))
         with self.client:
             self.login()
             resp = self.client.get('/suppliers/frameworks/does-not-exist/opportunities')
 
             assert resp.status_code == 404
 
-    def test_404_if_supplier_framework_does_not_exist(self, data_api_client):
-        data_api_client.get_framework.return_value = self.framework_response
-        data_api_client.get_supplier_framework_info.side_effect = APIError(mock.Mock(status_code=404))
+    def test_404_if_supplier_framework_does_not_exist(self):
+        self.data_api_client.get_framework.return_value = self.framework_response
+        self.data_api_client.get_supplier_framework_info.side_effect = APIError(mock.Mock(status_code=404))
         with self.client:
             self.login()
             resp = self.client.get(self.opportunities_dashboard_url)
 
             assert resp.status_code == 404
 
-    def test_404_if_framework_is_not_dos(self, data_api_client):
+    def test_404_if_framework_is_not_dos(self):
         self.framework_response['frameworks'].update({'slug': 'g-cloud-9', 'framework': 'g-cloud'})
-        data_api_client.get_framework.return_value = self.framework_response
-        data_api_client.get_supplier_framework_info.return_value = self.supplier_framework_response
+        self.data_api_client.get_framework.return_value = self.framework_response
+        self.data_api_client.get_supplier_framework_info.return_value = self.supplier_framework_response
         with self.client:
             self.login()
             resp = self.client.get('/suppliers/frameworks/g-cloud-9/opportunities')
 
             assert resp.status_code == 404
 
-    def test_404_if_supplier_not_on_framework(self, data_api_client):
-        data_api_client.get_framework.return_value = self.framework_response
+    def test_404_if_supplier_not_on_framework(self):
+        self.data_api_client.get_framework.return_value = self.framework_response
         self.supplier_framework_response['frameworkInterest'].update(
             {'onFramework': False}
         )
-        data_api_client.get_supplier_framework_info.return_value = self.supplier_framework_response
+        self.data_api_client.get_supplier_framework_info.return_value = self.supplier_framework_response
         with self.client:
             self.login()
             resp = self.client.get(self.opportunities_dashboard_url)
 
             assert resp.status_code == 404
 
-    def test_completed_list_of_opportunities(self, data_api_client):
+    def test_completed_list_of_opportunities(self):
         """Assert the 'Completed opportunities' table on this page contains the correct values."""
-        first_row, second_row, third_row = self.get_table_rows_by_id('submitted-opportunities', data_api_client)
+        first_row, second_row, third_row = self.get_table_rows_by_id('submitted-opportunities')
 
         assert 'Highest date, submitted, lowest id' in first_row.text_content()
         assert first_row.xpath('*//a/@href')[0] == '/suppliers/opportunities/100/responses/1/application'
         assert 'Thursday 8 June 2017' in first_row.text_content()
 
-    def test_completed_list_of_opportunities_ordered_by_applications_closed_at(self, data_api_client):
+    def test_completed_list_of_opportunities_ordered_by_applications_closed_at(self):
         """Assert the 'Completed opportunities' table on this page contains the brief responses in the correct order."""
-        first_row, second_row, third_row = self.get_table_rows_by_id('submitted-opportunities', data_api_client)
+        first_row, second_row, third_row = self.get_table_rows_by_id('submitted-opportunities')
 
         assert 'Highest date' in first_row.text_content()
         assert 'Mid date' in second_row.text_content()
         assert 'Lowest date' in third_row.text_content()
 
-    def _get_brief_response_dashboard_status(self, data_api_client, brief_response_status, brief_status):
+    def _get_brief_response_dashboard_status(self, brief_response_status, brief_status):
         self.find_brief_responses_response = {
             'briefResponses': [
                 {
@@ -156,35 +163,32 @@ class TestOpportunitiesDashboard(BaseApplicationTest):
                 },
             ]
         }
-        rows = self.get_table_rows_by_id('submitted-opportunities', data_api_client)
+        rows = self.get_table_rows_by_id('submitted-opportunities')
         return [row.getchildren()[2].text_content().strip() for row in rows][0]
 
-    def test_submitted_brief_response_for_open_brief_shows_submitted_status(self, data_api_client):
-        assert self._get_brief_response_dashboard_status(data_api_client, "submitted", "live") == "Submitted"
+    def test_submitted_brief_response_for_open_brief_shows_submitted_status(self):
+        assert self._get_brief_response_dashboard_status("submitted", "live") == "Submitted"
 
-    def test_submitted_brief_response_for_closed_brief_shows_submitted_status(self, data_api_client):
-        assert self._get_brief_response_dashboard_status(data_api_client, "submitted", "closed") == "Submitted"
+    def test_submitted_brief_response_for_closed_brief_shows_submitted_status(self):
+        assert self._get_brief_response_dashboard_status("submitted", "closed") == "Submitted"
 
-    def test_submitted_brief_response_for_cancelled_brief_shows_cancelled_status(self, data_api_client):
-        assert self._get_brief_response_dashboard_status(
-            data_api_client, "submitted", "cancelled") == "Opportunity cancelled"
+    def test_submitted_brief_response_for_cancelled_brief_shows_cancelled_status(self):
+        assert self._get_brief_response_dashboard_status("submitted", "cancelled") == "Opportunity cancelled"
 
-    def test_submitted_brief_response_for_unsuccessful_brief_shows_not_won_status(self, data_api_client):
-        assert self._get_brief_response_dashboard_status(data_api_client, "submitted", "unsuccessful") == "Not won"
+    def test_submitted_brief_response_for_unsuccessful_brief_shows_not_won_status(self):
+        assert self._get_brief_response_dashboard_status("submitted", "unsuccessful") == "Not won"
 
-    def test_submitted_brief_response_for_withdrawn_brief_shows_withdrawn_status(self, data_api_client):
-        assert self._get_brief_response_dashboard_status(
-            data_api_client, "submitted", "withdrawn") == "Opportunity withdrawn"
+    def test_submitted_brief_response_for_withdrawn_brief_shows_withdrawn_status(self):
+        assert self._get_brief_response_dashboard_status("submitted", "withdrawn") == "Opportunity withdrawn"
 
-    def test_brief_awarded_to_different_brief_response_shows_not_won_status(self, data_api_client):
-        assert self._get_brief_response_dashboard_status(data_api_client, "submitted", "awarded") == "Not won"
+    def test_brief_awarded_to_different_brief_response_shows_not_won_status(self):
+        assert self._get_brief_response_dashboard_status("submitted", "awarded") == "Not won"
 
-    def test_pending_award_brief_response_for_closed_brief_shows_submitted_status(self, data_api_client):
-        assert self._get_brief_response_dashboard_status(data_api_client, "pending-awarded", "closed") == "Submitted"
+    def test_pending_award_brief_response_for_closed_brief_shows_submitted_status(self):
+        assert self._get_brief_response_dashboard_status("pending-awarded", "closed") == "Submitted"
 
-    def test_pending_award_brief_response_for_cancelled_brief_shows_not_won_status(self, data_api_client):
-        assert self._get_brief_response_dashboard_status(
-            data_api_client, "pending-awarded", "cancelled") == "Opportunity cancelled"
+    def test_pending_award_brief_response_for_cancelled_brief_shows_not_won_status(self):
+        assert self._get_brief_response_dashboard_status("pending-awarded", "cancelled") == "Opportunity cancelled"
 
-    def test_awarded_brief_response_shows_won_status(self, data_api_client):
-        assert self._get_brief_response_dashboard_status(data_api_client, "awarded", "awarded") == "Won"
+    def test_awarded_brief_response_shows_won_status(self):
+        assert self._get_brief_response_dashboard_status("awarded", "awarded") == "Won"

--- a/tests/app/test_application.py
+++ b/tests/app/test_application.py
@@ -8,7 +8,7 @@ from dmapiclient.errors import HTTPError
 
 class TestApplication(BaseApplicationTest):
     def setup_method(self, method):
-        super(TestApplication, self).setup_method(method)
+        super().setup_method(method)
         self.login()
         self.data_api_client_patch = mock.patch('app.main.views.briefs.data_api_client')
         self.data_api_client = self.data_api_client_patch.start()
@@ -16,6 +16,7 @@ class TestApplication(BaseApplicationTest):
 
     def teardown_method(self, method):
         self.data_api_client_patch.stop()
+        super().teardown_method(method)
 
     def test_response_headers(self):
         response = self.client.get('/suppliers/opportunities/1/ask-a-question')

--- a/tests/app/test_application.py
+++ b/tests/app/test_application.py
@@ -9,10 +9,10 @@ from dmapiclient.errors import HTTPError
 class TestApplication(BaseApplicationTest):
     def setup_method(self, method):
         super().setup_method(method)
-        self.login()
         self.data_api_client_patch = mock.patch('app.main.views.briefs.data_api_client')
         self.data_api_client = self.data_api_client_patch.start()
         self.data_api_client.get_brief.return_value = api_stubs.brief(status='live')
+        self.login()
 
     def teardown_method(self, method):
         self.data_api_client_patch.stop()


### PR DESCRIPTION
Ongoing work to refactor the tests for the FE apps (see https://github.com/alphagov/digitalmarketplace-briefs-frontend/pull/93 and https://github.com/alphagov/digitalmarketplace-user-frontend/pull/56).

Not too much to tidy in this app:
- Python 3 `super()` syntax
- Moving `data_api_client` patching to the class `setup` method (instead of using a decorator)
- Adding explicit `teardown` methods