### PR TITLE
Remove do-not-reply email address

### DIFF
--- a/config.py
+++ b/config.py
@@ -28,7 +28,7 @@ class Config(object):
     DEBUG = False
 
     CLARIFICATION_EMAIL_NAME = 'Digital Marketplace Admin'
-    CLARIFICATION_EMAIL_FROM = 'do-not-reply@digitalmarketplace.service.gov.uk'
+    CLARIFICATION_EMAIL_FROM = 'enquiries@digitalmarketplace.service.gov.uk'
 
     SECRET_KEY = None
 

--- a/tests/app/main/test_briefs.py
+++ b/tests/app/main/test_briefs.py
@@ -272,7 +272,7 @@ class TestSubmitClarificationQuestions(BaseApplicationTest):
                 from_name='Brief Framework Name Supplier',
                 tags=['brief-clarification-question'],
                 email_body=FakeMail("important question"),
-                from_email='do-not-reply@digitalmarketplace.service.gov.uk',
+                from_email='enquiries@digitalmarketplace.service.gov.uk',
                 api_key='MANDRILL',
                 to_email_addresses=['buyer@email.com'],
                 subject=u"You\u2019ve received a new supplier question about \u2018I need a thing to do a thing\u2019"
@@ -281,7 +281,7 @@ class TestSubmitClarificationQuestions(BaseApplicationTest):
                 from_name='Digital Marketplace Admin',
                 tags=['brief-clarification-question-confirmation'],
                 email_body=FakeMail("important question"),
-                from_email='do-not-reply@digitalmarketplace.service.gov.uk',
+                from_email='enquiries@digitalmarketplace.service.gov.uk',
                 api_key='MANDRILL',
                 to_email_addresses=['email@email.com'],
                 subject=u"Your question about \u2018I need a thing to do a thing\u2019"


### PR DESCRIPTION
 ## Summary
We sometimes send emails from 'do-not-reply@digitalmarketplace...'. If a
user does reply to this, they get directed to email enquiries. We should
just set our reply-to address as enquiries directly.

Guidance: https://www.gov.uk/service-manual/technology/how-to-email-your-users#allow-users-to-reply-to-you