### PR TITLE
Rename framework_framework variable

### DIFF
--- a/app/main/helpers/briefs.py
+++ b/app/main/helpers/briefs.py
@@ -67,7 +67,7 @@ def send_brief_clarification_question(data_api_client, brief, clarification_ques
         "emails/brief_clarification_question_confirmation.html",
         brief_id=brief['id'],
         brief_name=brief['title'],
-        framework_framework=brief['frameworkFramework'],
+        framework_family=brief['frameworkFramework'],
         message=clarification_question
     )
     try:

--- a/app/main/views/briefs.py
+++ b/app/main/views/briefs.py
@@ -338,7 +338,7 @@ def redirect_to_public_opportunity_page(brief_id):
     """
     brief = get_brief(data_api_client, brief_id)
     return redirect(
-        url_for('external.get_brief_by_id', framework_framework=brief['frameworkFramework'], brief_id=brief_id)
+        url_for('external.get_brief_by_id', framework_family=brief['frameworkFramework'], brief_id=brief_id)
     )
 
 

--- a/app/templates/briefs/check_your_answers.html
+++ b/app/templates/briefs/check_your_answers.html
@@ -19,7 +19,7 @@
         "label": "Your {} opportunities".format(brief.frameworkName)
       },
       {
-        "link": url_for("external.get_brief_by_id", framework_framework=brief.frameworkFramework, brief_id=brief.id),
+        "link": url_for("external.get_brief_by_id", framework_family=brief.frameworkFramework, brief_id=brief.id),
         "label": "{}".format(brief.title)
       },
     ]
@@ -41,7 +41,7 @@
     <div class="dmspeak">
       {% if brief_response.status != 'draft' %}
       <p>
-        <a href="{{ url_for('external.get_brief_by_id', framework_framework='digital-outcomes-and-specialists', brief_id=brief.id) }}">View the opportunity{{ ' and its outcome' if brief.status in ["awarded", "cancelled", "unsuccessful"] }}</a>
+        <a href="{{ url_for('external.get_brief_by_id', framework_family='digital-outcomes-and-specialists', brief_id=brief.id) }}">View the opportunity{{ ' and its outcome' if brief.status in ["awarded", "cancelled", "unsuccessful"] }}</a>
       </p>
       {% endif %}
     </div>

--- a/app/templates/emails/brief_clarification_question_confirmation.html
+++ b/app/templates/emails/brief_clarification_question_confirmation.html
@@ -13,7 +13,7 @@
   ‘{{ message }}’
   <br /><br />
   Your question will be posted with the buyer’s answer on the ‘{{ brief_name }}’ page at:<br />
-  <a href="https://www.digitalmarketplace.service.gov.uk/{{ framework_framework }}/opportunities/{{ brief_id }}">https://www.digitalmarketplace.service.gov.uk/{{ framework_framework }}/opportunities/{{ brief_id }}</a><br />
+  <a href="https://www.digitalmarketplace.service.gov.uk/{{ framework_family }}/opportunities/{{ brief_id }}">https://www.digitalmarketplace.service.gov.uk/{{ framework_family }}/opportunities/{{ brief_id }}</a><br />
   <br />
   Thanks,<br />
   The Digital Marketplace team

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -5,6 +5,6 @@ Flask==0.10.1
 Flask-Login==0.2.11
 Flask-WTF==0.14.2
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@37.0.0#egg=digitalmarketplace-utils==37.0.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@38.0.0#egg=digitalmarketplace-utils==38.0.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.2.0#egg=digitalmarketplace-content-loader==4.2.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@15.0.0#egg=digitalmarketplace-apiclient==15.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ Flask==0.10.1
 Flask-Login==0.2.11
 Flask-WTF==0.14.2
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@37.0.0#egg=digitalmarketplace-utils==37.0.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@38.0.0#egg=digitalmarketplace-utils==38.0.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.2.0#egg=digitalmarketplace-content-loader==4.2.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@15.0.0#egg=digitalmarketplace-apiclient==15.0.0
 


### PR DESCRIPTION
 ## Summary
`framework_framework` is an unnecessarily obtuse variable name and is
not overly descriptive of what it actually means. When used, this
describes the 'family' of framework being referenced. For example,
G-Cloud 10 is in the 'G-Cloud' family of frameworks. Digital Outcomes
and Specialists 2 is in the 'Digital Outcomes and Specialists' family.
Let's change all the references of `framework_framework` to
`framework_family`.

 ## Ticket
https://trello.com/c/iqFcVKpd/14

 ## Dependencies
https://github.com/alphagov/digitalmarketplace-utils/pull/397