### PR TITLE
Iterate opt in flow for user research participants

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -18,6 +18,8 @@
 //= require ../../../node_modules/govuk_frontend_toolkit/javascripts/govuk/stop-scrolling-at-footer.js
 //= require ../../../node_modules/digitalmarketplace-frontend-toolkit/toolkit/javascripts/shim-links-with-button-role.js
 //= require ../../../node_modules/digitalmarketplace-frontend-toolkit/toolkit/javascripts/show-hide-content.js
+//= require ../../../node_modules/digitalmarketplace-frontend-toolkit/toolkit/javascripts/report-a-problem.js
+//= require ../../../node_modules/digitalmarketplace-frontend-toolkit/toolkit/javascripts/user-research-consent-banner.js
 //= require _analytics.js
 //= require _selection-buttons.js
 //= require _stick-at-top-when-scrolling.js

--- a/app/assets/scss/application.scss
+++ b/app/assets/scss/application.scss
@@ -46,6 +46,7 @@ $path: "/suppliers/opportunities/static/images/";
 @import "toolkit/forms/_checkbox-tree.scss";
 @import "toolkit/forms/_word-counter.scss";
 @import "toolkit/forms/_list-entry.scss";
+@import "toolkit/_user-research-consent-banner.scss";
 
 
 // App specific styles

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "colors": "1.1.2",
     "jquery": "1.12.0",
     "hogan.js": "3.0.2",
-    "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v29.0.0",
+    "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v30.1.0",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.19.2/jinja_govuk_template-0.19.2.tgz",
     "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#9.2.0"
   },

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "colors": "1.1.2",
     "jquery": "1.12.0",
     "hogan.js": "3.0.2",
-    "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v30.1.0",
+    "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v31.0.0",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.19.2/jinja_govuk_template-0.19.2.tgz",
     "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#9.2.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -523,9 +523,9 @@ detect-file@^1.0.0:
   version "0.0.0"
   resolved "https://github.com/alphagov/digitalmarketplace-frameworks.git#277c960596a64f296682306860ca9403748b6e60"
 
-"digitalmarketplace-frontend-toolkit@https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v29.0.0":
-  version "29.0.0"
-  resolved "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#87b8535689b160c26c0ac53d9d6bb96cde10c277"
+"digitalmarketplace-frontend-toolkit@https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v31.0.0":
+  version "31.0.0"
+  resolved "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#f0b6e4ce678ac7257f187e3b5bb43a0c143b4694"
   dependencies:
     del "^2.2.2"
     govuk-elements-sass "3.0.3"


### PR DESCRIPTION
**As a buyer I want to easily opt-in to user research so that I can help improve the buyer experience for G-Cloud**

The current opt-in journey has been unsuccessful, only 6 buyers have signed up. A higher number of suppliers, however, we suspect that this is due to G10 submission going on at the same time.

Buyer and suppliers cannot opt-in until they log in. Buyers and suppliers that don't log in don't have an opportunity to opt-in for user research.

***

**Changes**

Cookie banner to appear on all pages for logged in and logged out users until they click close or opt in. If clicked close, it reappears after 90 days.

***

**Notes**

Users will have to log in before they can opt-in.
We should use the existing opt-in journey as much as possible. This is non-mission work.

Ticket: https://trello.com/c/48pZNhaG/120-iterate-opt-in-flow-for-user-research-participants