### PR TITLE
Fix validation for brief clarification

### DIFF
--- a/app/main/forms/briefs.py
+++ b/app/main/forms/briefs.py
@@ -1,3 +1,4 @@
+from flask import escape, Markup
 from flask_wtf import FlaskForm
 from wtforms import validators
 
@@ -14,8 +15,9 @@ class AskClarificationQuestionForm(FlaskForm):
                                       message='Question must be no more than 100 words')]
     )
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, brief, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        self.clarification_question.label.text = Markup(f'Ask a question about ‘{escape(brief["title"])}’')
         self.clarification_question.advice = (
             'Your question will be published with the buyer’s answer by {}. All questions and answers will be posted '
             'on the Digital Marketplace. Your company name won’t be visible. You shouldn’t include any confidential '

--- a/app/main/views/briefs.py
+++ b/app/main/views/briefs.py
@@ -43,7 +43,6 @@ def question_and_answer_session(brief_id):
 
 @main.route('/<int:brief_id>/ask-a-question', methods=['GET', 'POST'])
 def ask_brief_clarification_question(brief_id):
-    form = AskClarificationQuestionForm()
     brief = get_brief(data_api_client, brief_id, allowed_statuses=['live'])
 
     if brief['clarificationQuestionsAreClosed']:
@@ -52,6 +51,7 @@ def ask_brief_clarification_question(brief_id):
     if not is_supplier_eligible_for_brief(data_api_client, current_user.supplier_id, brief):
         return _render_not_eligible_for_brief_error_page(brief, clarification_question=True)
 
+    form = AskClarificationQuestionForm(brief)
     if form.validate_on_submit():
         send_brief_clarification_question(data_api_client, brief, form.clarification_question.data)
         flash(CLARIFICATION_QUESTION_SENT_MESSAGE.format(brief=brief))

--- a/app/templates/briefs/clarification_question.html
+++ b/app/templates/briefs/clarification_question.html
@@ -29,7 +29,7 @@
     <div class="column-two-thirds">
 
       {% with
-        heading = "Ask a question about ‘{}’".format(brief.title),
+        heading = form.clarification_question.label.text,
         smaller = true
       %}
         {% include 'toolkit/page-heading.html' %}
@@ -41,7 +41,7 @@
           with
           large = true,
           name = 'clarification_question',
-          question = form.clarification_question.label,
+          question = form.clarification_question.label.text,
           error = errors.get('clarification_question', {}).get('message', None),
           max_length_in_words = 100,
           question_advice = form.clarification_question.advice.format(brief.clarificationQuestionsPublishedBy|dateformat)|safe


### PR DESCRIPTION
 ## Summary
The validation link in the masthead was missing the `about
'brief.title'` bit after the masthead consolidation. This adds it back in.