### PR TITLE
Bump utils & docker base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,1 @@
-FROM digitalmarketplace/base-frontend:3.1.2
+FROM digitalmarketplace/base-frontend:3.2.0

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -5,6 +5,6 @@ Flask==0.10.1
 Flask-Login==0.2.11
 Flask-WTF==0.14.2
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@38.0.0#egg=digitalmarketplace-utils==38.0.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@39.3.0#egg=digitalmarketplace-utils==39.3.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.2.0#egg=digitalmarketplace-content-loader==4.2.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@15.0.0#egg=digitalmarketplace-apiclient==15.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ Flask==0.10.1
 Flask-Login==0.2.11
 Flask-WTF==0.14.2
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@38.0.0#egg=digitalmarketplace-utils==38.0.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@39.3.0#egg=digitalmarketplace-utils==39.3.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.2.0#egg=digitalmarketplace-content-loader==4.2.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@15.0.0#egg=digitalmarketplace-apiclient==15.0.0
 
@@ -25,7 +25,7 @@ docutils==0.14
 Flask-FeatureFlags==0.6
 Flask-Script==2.0.6
 future==0.16.0
-idna==2.6
+idna==2.7
 inflection==0.3.1
 itsdangerous==0.24
 Jinja2==2.10
@@ -50,4 +50,4 @@ unicodecsv==0.14.1
 urllib3==1.22
 Werkzeug==0.14.1
 workdays==1.4
-WTForms==2.1
+WTForms==2.2.1


### PR DESCRIPTION
Another double bump here.

This should allow zipkin logging to work better in both the nginx and app logs and also fix a medium security issue.