### PR TITLE
Draft applications on supplier dashboard

### DIFF
--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -6,6 +6,8 @@ from dmapiclient import APIError
 from ... import data_api_client
 from ...main import main
 
+BRIEF_RESPONSE_STATUSES = ['draft', 'submitted', 'pending-awarded', 'awarded']
+
 
 @main.route('/frameworks/<framework_slug>', methods=['GET'])
 def opportunities_dashboard(framework_slug):
@@ -20,11 +22,20 @@ def opportunities_dashboard(framework_slug):
     if not (framework['framework'] == 'digital-outcomes-and-specialists' and supplier_framework['onFramework']):
         abort(404)
     opportunities = data_api_client.find_brief_responses(
-        supplier_id=current_user.supplier_id, framework=framework_slug
+        supplier_id=current_user.supplier_id, framework=framework_slug, status=",".join(BRIEF_RESPONSE_STATUSES)
     )['briefResponses']
+
+    # Split into two tables by status
+    drafts, completed = [], []
+    for opportunity in opportunities:
+        if opportunity['status'] == 'draft':
+            drafts.append(opportunity)
+        else:
+            completed.append(opportunity)
 
     return render_template(
         "frameworks/opportunities_dashboard.html",
         framework=framework,
-        completed=opportunities
+        completed=completed,
+        drafts=drafts,
     ), 200

--- a/app/templates/frameworks/opportunities_dashboard.html
+++ b/app/templates/frameworks/opportunities_dashboard.html
@@ -39,6 +39,36 @@
     </a>
   </p>
 
+{{ summary.heading("Applications you’ve started", id="draft-opportunities") }}
+{% call(item) summary.list_table(
+    drafts|sort(attribute='brief.applicationsClosedAt', reverse=True),
+    caption="Draft opportunities",
+    empty_message="You don’t have any draft applications",
+    field_headings=[
+        "Application",
+        "Deadline",
+        "Status",
+        summary.hidden_field_heading("Complete your draft application")
+    ],
+    field_headings_visible=True
+) %}
+
+    {% call summary.row() %}
+        {% call summary.field(first=True) %}
+            {{ item.brief.title }}
+        {% endcall %}
+        {{ summary.text(item.brief.applicationsClosedAt|dateformat) }}
+        {{ summary.text("Draft") }}
+        {% with url =
+            url_for('.check_brief_response_answers', brief_id=item.briefId, brief_response_id=item.id) if item.essentialRequirementsMet else
+            url_for('.start_brief_response', brief_id=item.briefId)
+        %}
+            {% call summary.field(action=True) %}
+                <a href="{{ url }}">Complete your application</a>
+            {% endcall %}
+        {% endwith %}
+    {% endcall %}
+{% endcall %}
 
 {{ summary.heading("Applications you’ve made", id="submitted-opportunities") }}
 {% call(item) summary.list_table(

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -55,6 +55,28 @@ class TestOpportunitiesDashboard(BaseApplicationTest):
                 },
                 'id': 3,
                 'status': 'submitted',
+            },
+            {
+                'briefId': 5653,
+                'brief': {
+                    'title': 'Lowest date, draft',
+                    'applicationsClosedAt': '2017-06-06T10:26:21.538917Z',
+                    'status': 'live',
+                    'frameworkSlug': 'digital-outcomes-and-specialists-2'
+                },
+                'id': 4,
+                'status': 'draft',
+            },
+            {
+                'briefId': 9999,
+                'brief': {
+                    'title': 'Highest date, draft',
+                    'applicationsClosedAt': '2017-06-07T10:26:21.538917Z',
+                    'status': 'live',
+                    'frameworkSlug': 'digital-outcomes-and-specialists-2'
+                },
+                'id': 5,
+                'status': 'draft',
             }
         ]}
         self.login()
@@ -87,7 +109,8 @@ class TestOpportunitiesDashboard(BaseApplicationTest):
         assert resp.status_code == 200
         self.data_api_client.find_brief_responses.assert_called_once_with(
             supplier_id=1234,
-            framework='digital-outcomes-and-specialists-2'
+            framework='digital-outcomes-and-specialists-2',
+            status='draft,submitted,pending-awarded,awarded'
         )
 
     def test_404_if_framework_does_not_exist(self):
@@ -140,6 +163,13 @@ class TestOpportunitiesDashboard(BaseApplicationTest):
         assert 'Highest date' in first_row.text_content()
         assert 'Mid date' in second_row.text_content()
         assert 'Lowest date' in third_row.text_content()
+
+    def test_draft_list_of_opportunities_ordered_by_applications_closed_at(self):
+        """Assert the 'Draft opportunities' table on this page contains the brief responses in the correct order."""
+        first_row, second_row = self.get_table_rows_by_id('draft-opportunities')
+
+        assert 'Highest date' in first_row.text_content()
+        assert 'Lowest date' in second_row.text_content()
 
     def _get_brief_response_dashboard_status(self, brief_response_status, brief_status):
         self.find_brief_responses_response = {


### PR DESCRIPTION
Trello: https://trello.com/c/WOrGaxBH/104-show-draft-applications-on-supplier-dashboard

Shows suppliers their draft applications in their dashboard, so they are less likely to mistakenly think their draft has already been submitted.

Old dashboard:
![old-supplier-dashboard](https://user-images.githubusercontent.com/3492540/41860799-78d4403c-7897-11e8-80b0-42c1e9f7076c.png)

New dashboard:
![final-final-v2-do-not-change](https://user-images.githubusercontent.com/3492540/41860808-7dca946a-7897-11e8-9182-ffae7b7f385d.png)

Content and layout approved by @constancecerf. 

The functional tests pass locally.

A quirk in the application flow means that for now the 'Complete your application' link goes to the 'Check Your Answers' page only if the supplier has completed all the sections (but hasn't submitted). Otherwise we go to the start of the application journey for that brief (any saved answers will still show up). This is because the content loader manifest gets hugely confused if we jump to Check Your Answers early. This was a known issue when we built the Check Your Answers page, but wasn't a priority to fix.
