### PR TITLE
Draft applications should be sorted with the earliest deadline first

### DIFF
--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -1,8 +1,10 @@
 # coding: utf-8
 
+from datetime import datetime, timedelta
 from flask import render_template, abort
 from flask_login import current_user
 from dmapiclient import APIError
+from dmutils.formats import DATETIME_FORMAT
 from ... import data_api_client
 from ...main import main
 
@@ -27,9 +29,13 @@ def opportunities_dashboard(framework_slug):
 
     # Split into two tables by status
     drafts, completed = [], []
+    two_weeks_ago = (datetime.now() - timedelta(days=14))
     for opportunity in opportunities:
         if opportunity['status'] == 'draft':
+            # Show applications for live briefs and briefs that closed up to 2 weeks ago
             if opportunity['brief']['status'] == 'live':
+                drafts.append(opportunity)
+            elif opportunity['brief']['applicationsClosedAt'] > two_weeks_ago.strftime(DATETIME_FORMAT):
                 drafts.append(opportunity)
         else:
             completed.append(opportunity)

--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -29,7 +29,8 @@ def opportunities_dashboard(framework_slug):
     drafts, completed = [], []
     for opportunity in opportunities:
         if opportunity['status'] == 'draft':
-            drafts.append(opportunity)
+            if opportunity['brief']['status'] == 'live':
+                drafts.append(opportunity)
         else:
             completed.append(opportunity)
 

--- a/app/templates/frameworks/opportunities_dashboard.html
+++ b/app/templates/frameworks/opportunities_dashboard.html
@@ -64,7 +64,11 @@
             url_for('.start_brief_response', brief_id=item.briefId)
         %}
             {% call summary.field(action=True) %}
-                {% if item.brief.status == 'live' %}<a href="{{ url }}">Complete your application</a>{% else %}Applications closed{% endif %}
+                {% if item.brief.status == 'live' %}
+                    <a href="{{ url }}">Complete your application</a>
+                {% else %}
+                    <a href="{{ url_for('external.get_brief_by_id', framework_family=item.brief.framework.family, brief_id=item.briefId) }}">Applications closed</a>
+                {% endif %}
             {% endcall %}
         {% endwith %}
     {% endcall %}

--- a/app/templates/frameworks/opportunities_dashboard.html
+++ b/app/templates/frameworks/opportunities_dashboard.html
@@ -64,7 +64,7 @@
             url_for('.start_brief_response', brief_id=item.briefId)
         %}
             {% call summary.field(action=True) %}
-                <a href="{{ url }}">Complete your application</a>
+                {% if item.brief.status == 'live' %}<a href="{{ url }}">Complete your application</a>{% else %}Applications closed{% endif %}
             {% endcall %}
         {% endwith %}
     {% endcall %}

--- a/app/templates/frameworks/opportunities_dashboard.html
+++ b/app/templates/frameworks/opportunities_dashboard.html
@@ -41,7 +41,7 @@
 
 {{ summary.heading("Applications you’ve started", id="draft-opportunities") }}
 {% call(item) summary.list_table(
-    drafts|sort(attribute='brief.applicationsClosedAt', reverse=True),
+    drafts|sort(attribute='brief.applicationsClosedAt'),
     caption="Draft opportunities",
     empty_message="You don’t have any draft applications",
     field_headings=[

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -15,6 +15,13 @@ class TestOpportunitiesDashboard(BaseApplicationTest):
         self.data_api_client_patch = mock.patch('app.main.views.frameworks.data_api_client', autospec=True)
         self.data_api_client = self.data_api_client_patch.start()
 
+        self.brief_framework_data = {
+            "family": "digital-outcomes-and-specialists",
+            "name": "Digital Outcomes and Specialists 2",
+            "slug": "digital-outcomes-and-specialists-2",
+            "status": "live"
+        }
+
         self.framework_response = {
             'frameworks': {
                 'slug': 'digital-outcomes-and-specialists-2',
@@ -31,7 +38,7 @@ class TestOpportunitiesDashboard(BaseApplicationTest):
                     'title': 'Highest date, submitted, lowest id',
                     'applicationsClosedAt': '2017-06-08T10:26:21.538917Z',
                     'status': 'closed',
-                    'frameworkSlug': 'digital-outcomes-and-specialists-2'
+                    "framework": self.brief_framework_data,
                 },
                 'id': 1,
                 'status': 'submitted',
@@ -42,7 +49,7 @@ class TestOpportunitiesDashboard(BaseApplicationTest):
                     'title': 'Lowest date, submitted, mid id',
                     'applicationsClosedAt': '2017-06-06T10:26:21.538917Z',
                     'status': 'closed',
-                    'frameworkSlug': 'digital-outcomes-and-specialists-2'
+                    "framework": self.brief_framework_data,
                 },
                 'id': 2,
                 'status': 'submitted',
@@ -53,7 +60,7 @@ class TestOpportunitiesDashboard(BaseApplicationTest):
                     'title': 'Mid date, submitted, highest id',
                     'applicationsClosedAt': '2017-06-07T10:26:21.538917Z',
                     'status': 'withdrawn',
-                    'frameworkSlug': 'digital-outcomes-and-specialists-2'
+                    "framework": self.brief_framework_data,
                 },
                 'id': 3,
                 'status': 'submitted',
@@ -64,7 +71,7 @@ class TestOpportunitiesDashboard(BaseApplicationTest):
                     'title': 'Highest date, draft',
                     'applicationsClosedAt': '2017-06-07T10:26:21.538917Z',
                     'status': 'live',
-                    'frameworkSlug': 'digital-outcomes-and-specialists-2'
+                    "framework": self.brief_framework_data,
                 },
                 'id': 4,
                 'status': 'draft',
@@ -75,7 +82,7 @@ class TestOpportunitiesDashboard(BaseApplicationTest):
                     'title': 'Lowest date, draft',
                     'applicationsClosedAt': '2017-06-05T10:26:21.538917Z',
                     'status': 'live',
-                    'frameworkSlug': 'digital-outcomes-and-specialists-2'
+                    "framework": self.brief_framework_data,
                 },
                 'id': 5,
                 'status': 'draft',
@@ -86,7 +93,7 @@ class TestOpportunitiesDashboard(BaseApplicationTest):
                     'title': 'Middle date, draft',
                     'applicationsClosedAt': '2017-06-06T10:26:21.538917Z',
                     'status': 'closed',
-                    'frameworkSlug': 'digital-outcomes-and-specialists-2'
+                    "framework": self.brief_framework_data,
                 },
                 'id': 6,
                 'status': 'draft',
@@ -97,7 +104,7 @@ class TestOpportunitiesDashboard(BaseApplicationTest):
                     'title': 'Ancient date, draft',
                     'applicationsClosedAt': '2017-06-01T23:59:59.999999Z',
                     'status': 'closed',
-                    'frameworkSlug': 'digital-outcomes-and-specialists-2'
+                    "framework": self.brief_framework_data,
                 },
                 'id': 7,
                 'status': 'draft',
@@ -207,7 +214,7 @@ class TestOpportunitiesDashboard(BaseApplicationTest):
                         'title': f'{brief_response_status} brief response for {brief_status} opportunity',
                         'applicationsClosedAt': '2017-06-09T10:26:21.538917Z',
                         'status': brief_status,
-                        'frameworkSlug': 'digital-outcomes-and-specialists-2'
+                        'framework': self.brief_framework_data
                     },
                     'id': 999,
                     'status': brief_response_status,
@@ -243,7 +250,7 @@ class TestOpportunitiesDashboard(BaseApplicationTest):
         assert [row.getchildren()[3].text_content().strip() for row in rows][0] == "Complete your application"
 
     @pytest.mark.parametrize('brief_status', ['closed', 'cancelled', 'unsuccessful', 'withdrawn', 'awarded'])
-    def test_draft_brief_response_for_non_live_briefs_shows_applications_closed_message(self, brief_status):
+    def test_draft_brief_response_for_non_live_briefs_shows_applications_closed_link(self, brief_status):
         with freeze_time('2017-06-23 10:26:21'):
             rows = self._get_brief_response_dashboard_status('draft', brief_status, application_state='draft')
 

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -59,8 +59,8 @@ class TestOpportunitiesDashboard(BaseApplicationTest):
             {
                 'briefId': 5653,
                 'brief': {
-                    'title': 'Lowest date, draft',
-                    'applicationsClosedAt': '2017-06-06T10:26:21.538917Z',
+                    'title': 'Highest date, draft',
+                    'applicationsClosedAt': '2017-06-07T10:26:21.538917Z',
                     'status': 'live',
                     'frameworkSlug': 'digital-outcomes-and-specialists-2'
                 },
@@ -70,8 +70,8 @@ class TestOpportunitiesDashboard(BaseApplicationTest):
             {
                 'briefId': 9999,
                 'brief': {
-                    'title': 'Highest date, draft',
-                    'applicationsClosedAt': '2017-06-07T10:26:21.538917Z',
+                    'title': 'Lowest date, draft',
+                    'applicationsClosedAt': '2017-06-06T10:26:21.538917Z',
                     'status': 'live',
                     'frameworkSlug': 'digital-outcomes-and-specialists-2'
                 },
@@ -168,8 +168,8 @@ class TestOpportunitiesDashboard(BaseApplicationTest):
         """Assert the 'Draft opportunities' table on this page contains the brief responses in the correct order."""
         first_row, second_row = self.get_table_rows_by_id('draft-opportunities')
 
-        assert 'Highest date' in first_row.text_content()
-        assert 'Lowest date' in second_row.text_content()
+        assert 'Lowest date' in first_row.text_content()
+        assert 'Highest date' in second_row.text_content()
 
     def _get_brief_response_dashboard_status(self, brief_response_status, brief_status):
         self.find_brief_responses_response = {


### PR DESCRIPTION
Trello: https://trello.com/c/WOrGaxBH/104-show-draft-applications-on-supplier-dashboard

Ordering fail! The supplier should see the most urgent draft application at the top of the list.

![ordering-fail](https://user-images.githubusercontent.com/3492540/41905209-6b27035c-7932-11e8-8cfb-c2f63ac6f0d7.png)

I thought I'd done this ordering, and even wrote a test, but in fact I'd done the exact opposite 🤦‍♀️ 

