### PR TITLE
apiclient dependency: bump to v17.2.0

### DIFF
--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -7,4 +7,4 @@ Flask-WTF==0.14.2
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@39.3.0#egg=digitalmarketplace-utils==39.3.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.2.0#egg=digitalmarketplace-content-loader==4.2.0
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@15.0.0#egg=digitalmarketplace-apiclient==15.0.0
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@17.2.0#egg=digitalmarketplace-apiclient==17.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ Flask-WTF==0.14.2
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@39.3.0#egg=digitalmarketplace-utils==39.3.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.2.0#egg=digitalmarketplace-content-loader==4.2.0
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@15.0.0#egg=digitalmarketplace-apiclient==15.0.0
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@17.2.0#egg=digitalmarketplace-apiclient==17.2.0
 
 ## The following requirements were added by pip freeze:
 asn1crypto==0.24.0

--- a/tests/app/main/test_briefs.py
+++ b/tests/app/main/test_briefs.py
@@ -5,8 +5,9 @@ import mock
 import pytest
 from lxml import html
 
-from dmapiclient import api_stubs, HTTPError
+from dmapiclient import HTTPError
 from dmapiclient.audit import AuditTypes
+from dmutils import api_stubs
 from dmutils.email.exceptions import EmailError
 
 from app.main.views.briefs import _render_not_eligible_for_brief_error_page, PUBLISHED_BRIEF_STATUSES

--- a/tests/app/test_application.py
+++ b/tests/app/test_application.py
@@ -2,7 +2,7 @@
 
 import mock
 from .helpers import BaseApplicationTest
-from dmapiclient import api_stubs
+from dmutils import api_stubs
 from dmapiclient.errors import HTTPError
 
 


### PR DESCRIPTION
This brings in `childSpanId` logging.