### PR TITLE
Use external route instead of hardcoded URLs

### DIFF
--- a/app/main/helpers/briefs.py
+++ b/app/main/helpers/briefs.py
@@ -67,7 +67,7 @@ def send_brief_clarification_question(data_api_client, brief, clarification_ques
         "emails/brief_clarification_question_confirmation.html",
         brief_id=brief['id'],
         brief_name=brief['title'],
-        framework_family=brief['frameworkFramework'],
+        framework_family=brief['framework']['family'],
         message=clarification_question
     )
     try:

--- a/app/main/views/briefs.py
+++ b/app/main/views/briefs.py
@@ -341,7 +341,7 @@ def redirect_to_public_opportunity_page(brief_id):
     """
     brief = get_brief(data_api_client, brief_id)
     return redirect(
-        url_for('external.get_brief_by_id', framework_family=brief['frameworkFramework'], brief_id=brief_id)
+        url_for('external.get_brief_by_id', framework_family=brief['framework']['family'], brief_id=brief_id)
     )
 
 

--- a/app/templates/briefs/check_your_answers.html
+++ b/app/templates/briefs/check_your_answers.html
@@ -19,7 +19,7 @@
         "label": "Your {} opportunities".format(brief.frameworkName)
       },
       {
-        "link": url_for("external.get_brief_by_id", framework_family=brief.frameworkFramework, brief_id=brief.id),
+        "link": url_for("external.get_brief_by_id", framework_family=brief.framework.family, brief_id=brief.id),
         "label": "{}".format(brief.title)
       },
     ]

--- a/app/templates/briefs/clarification_question.html
+++ b/app/templates/briefs/clarification_question.html
@@ -57,7 +57,7 @@
         {% endwith %}
       </form>
 
-      <a href="{{ url_for('external.get_brief_by_id', framework_family=brief.frameworkFramework, brief_id=brief.id) }}">Return to {{ brief.title }}</a>
+      <a href="{{ url_for('external.get_brief_by_id', framework_family=brief.framework.family, brief_id=brief.id) }}">Return to {{ brief.title }}</a>
     </div>
   </div>
 </div>

--- a/app/templates/briefs/clarification_question.html
+++ b/app/templates/briefs/clarification_question.html
@@ -57,8 +57,7 @@
         {% endwith %}
       </form>
 
-      <a href="/{{ brief.frameworkFramework }}/opportunities/{{ brief.id }}">Return to {{ brief.title }}</a>
-
+      <a href="{{ url_for('external.get_brief_by_id', framework_family=brief.frameworkFramework, brief_id=brief.id) }}">Return to {{ brief.title }}</a>
     </div>
   </div>
 </div>

--- a/app/templates/briefs/edit_brief_response_question.html
+++ b/app/templates/briefs/edit_brief_response_question.html
@@ -9,11 +9,11 @@
         "label": "Digital Marketplace"
       },
       {
-        "link": "/{}/opportunities".format(brief.frameworkFramework),
+        "link": "/{}/opportunities".format(brief.framework.family),
         "label": "Supplier opportunities"
       },
       {
-        "link": url_for('external.get_brief_by_id', framework_family=brief.frameworkFramework, brief_id=brief.id),
+        "link": url_for('external.get_brief_by_id', framework_family=brief.framework.family, brief_id=brief.id),
         "label": brief.title
       },
     ]

--- a/app/templates/briefs/edit_brief_response_question.html
+++ b/app/templates/briefs/edit_brief_response_question.html
@@ -13,7 +13,7 @@
         "label": "Supplier opportunities"
       },
       {
-        "link": "/{}/opportunities/{}".format(brief.frameworkFramework, brief.id),
+        "link": url_for('external.get_brief_by_id', framework_family=brief.frameworkFramework, brief_id=brief.id),
         "label": brief.title
       },
     ]

--- a/app/templates/briefs/edit_brief_response_question.html
+++ b/app/templates/briefs/edit_brief_response_question.html
@@ -9,7 +9,7 @@
         "label": "Digital Marketplace"
       },
       {
-        "link": "/{}/opportunities".format(brief.framework.family),
+        "link": url_for('external.list_opportunities', framework_family=brief.framework.family),
         "label": "Supplier opportunities"
       },
       {

--- a/app/templates/briefs/question_and_answer_session.html
+++ b/app/templates/briefs/question_and_answer_session.html
@@ -36,7 +36,7 @@
       </p>
     </div>
 
-    <a href="{{ url_for('external.get_brief_by_id', framework_family=brief.frameworkFramework, brief_id=brief.id) }}">Return to {{ brief.title }}</a>
+    <a href="{{ url_for('external.get_brief_by_id', framework_family=brief.framework.family, brief_id=brief.id) }}">Return to {{ brief.title }}</a>
   </div>
 </div>
 {% endblock %}

--- a/app/templates/briefs/question_and_answer_session.html
+++ b/app/templates/briefs/question_and_answer_session.html
@@ -36,8 +36,7 @@
       </p>
     </div>
 
-
-    <a href="/{{ brief.frameworkFramework }}/opportunities/{{ brief.id }}">Return to {{ brief.title }}</a>
+    <a href="{{ url_for('external.get_brief_by_id', framework_family=brief.frameworkFramework, brief_id=brief.id) }}">Return to {{ brief.title }}</a>
   </div>
 </div>
 {% endblock %}

--- a/app/templates/briefs/start_brief_response.html
+++ b/app/templates/briefs/start_brief_response.html
@@ -14,7 +14,7 @@
         "label": "Supplier opportunities"
       },
       {
-        "link": "/{}/opportunities/{}".format(brief.frameworkFramework, brief.id),
+        "link": url_for('external.get_brief_by_id', framework_family=brief.frameworkFramework, brief_id=brief.id),
         "label": brief.title
       },
     ]

--- a/app/templates/briefs/start_brief_response.html
+++ b/app/templates/briefs/start_brief_response.html
@@ -10,11 +10,11 @@
         "label": "Digital Marketplace"
       },
       {
-        "link": "/{}/opportunities".format(brief.frameworkFramework),
+        "link": "/{}/opportunities".format(brief.framework.family),
         "label": "Supplier opportunities"
       },
       {
-        "link": url_for('external.get_brief_by_id', framework_family=brief.frameworkFramework, brief_id=brief.id),
+        "link": url_for('external.get_brief_by_id', framework_family=brief.framework.family, brief_id=brief.id),
         "label": brief.title
       },
     ]

--- a/app/templates/briefs/start_brief_response.html
+++ b/app/templates/briefs/start_brief_response.html
@@ -10,7 +10,7 @@
         "label": "Digital Marketplace"
       },
       {
-        "link": "/{}/opportunities".format(brief.framework.family),
+        "link": url_for('external.list_opportunities', framework_family=brief.framework.family),
         "label": "Supplier opportunities"
       },
       {

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -5,6 +5,6 @@ Flask==0.10.1
 Flask-Login==0.2.11
 Flask-WTF==0.14.2
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@39.3.0#egg=digitalmarketplace-utils==39.3.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@39.4.1#egg=digitalmarketplace-utils==39.4.1
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.2.0#egg=digitalmarketplace-content-loader==4.2.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@17.2.0#egg=digitalmarketplace-apiclient==17.2.0

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -5,6 +5,6 @@ Flask==0.10.1
 Flask-Login==0.2.11
 Flask-WTF==0.14.2
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@39.4.1#egg=digitalmarketplace-utils==39.4.1
+git+https://github.com/alphagov/digitalmarketplace-utils.git@39.5.0#egg=digitalmarketplace-utils==39.5.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.2.0#egg=digitalmarketplace-content-loader==4.2.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@17.2.0#egg=digitalmarketplace-apiclient==17.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ Flask==0.10.1
 Flask-Login==0.2.11
 Flask-WTF==0.14.2
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@39.3.0#egg=digitalmarketplace-utils==39.3.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@39.4.1#egg=digitalmarketplace-utils==39.4.1
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.2.0#egg=digitalmarketplace-content-loader==4.2.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@17.2.0#egg=digitalmarketplace-apiclient==17.2.0
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ Flask==0.10.1
 Flask-Login==0.2.11
 Flask-WTF==0.14.2
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@39.4.1#egg=digitalmarketplace-utils==39.4.1
+git+https://github.com/alphagov/digitalmarketplace-utils.git@39.5.0#egg=digitalmarketplace-utils==39.5.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.2.0#egg=digitalmarketplace-content-loader==4.2.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@17.2.0#egg=digitalmarketplace-apiclient==17.2.0
 


### PR DESCRIPTION
Trello: https://trello.com/c/PiwkC92B/476-brief-responses-templates-have-hardcoded-urls

Uses the external route for the public opportunity page (found on the Buyer FE app) rather than hardcoding.

Unfortunately we don't yet have an external route in `dmutils` for `/digital-outcomes-and-specialists/opportunities`.

Also pulls in the latest `utils.api_stubs` to make use of `framework.family` instead of `frameworkFramework`.