### PR TITLE
Pull in latest frameworks for DOS3

### DIFF
--- a/app/main/__init__.py
+++ b/app/main/__init__.py
@@ -18,6 +18,9 @@ content_loader.load_manifest('digital-outcomes-and-specialists-2', 'briefs', 'ed
 content_loader.load_manifest('digital-outcomes-and-specialists-2', 'brief-responses', 'edit_brief_response')
 content_loader.load_manifest('digital-outcomes-and-specialists-2', 'brief-responses', 'display_brief_response')
 
+content_loader.load_manifest('digital-outcomes-and-specialists-3', 'briefs', 'edit_brief')
+content_loader.load_manifest('digital-outcomes-and-specialists-3', 'brief-responses', 'edit_brief_response')
+content_loader.load_manifest('digital-outcomes-and-specialists-3', 'brief-responses', 'display_brief_response')
 
 main.before_request(partial(require_login, role='supplier'))
 

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "hogan.js": "3.0.2",
     "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v31.0.1",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.19.2/jinja_govuk_template-0.19.2.tgz",
-    "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#9.2.0"
+    "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#13.1.0"
   },
   "scripts": {
     "frontend-build:development": "./node_modules/gulp/bin/gulp.js build:development",

--- a/yarn.lock
+++ b/yarn.lock
@@ -519,9 +519,9 @@ detect-file@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/detect-file/-/detect-file-1.0.0.tgz#f0d66d03672a825cb1b73bdb3fe62310c8e552b7"
 
-"digitalmarketplace-frameworks@https://github.com/alphagov/digitalmarketplace-frameworks.git#9.2.0":
-  version "0.0.0"
-  resolved "https://github.com/alphagov/digitalmarketplace-frameworks.git#277c960596a64f296682306860ca9403748b6e60"
+"digitalmarketplace-frameworks@https://github.com/alphagov/digitalmarketplace-frameworks.git#13.1.0":
+  version "13.1.0"
+  resolved "https://github.com/alphagov/digitalmarketplace-frameworks.git#d51ee0b7c1751b0d08d6ddf14bd64d12b9783f57"
 
 "digitalmarketplace-frontend-toolkit@https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v31.0.1":
   version "31.0.1"


### PR DESCRIPTION
For [this trello ticket.](https://trello.com/c/VkAyVrzT)

See [this PR on the frameworks repo.](https://github.com/alphagov/digitalmarketplace-frameworks/pull/531)

DOS3 is coming and we need the manifests/questions etc.