### PR TITLE
Pulls in latest utils to fix /suppliers/opportunities 500 error

### DIFF
--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -5,6 +5,7 @@ Flask==0.10.1
 Flask-Login==0.2.11
 Flask-WTF==0.14.2
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@39.5.0#egg=digitalmarketplace-utils==39.5.0
+git+https://github.com/alphagov/Flask-FeatureFlags.git@1.0#egg=Flask-FeatureFlags==1.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@40.6.0#egg=digitalmarketplace-utils==40.6.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.2.0#egg=digitalmarketplace-content-loader==4.2.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@17.2.0#egg=digitalmarketplace-apiclient==17.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,8 @@ Flask==0.10.1
 Flask-Login==0.2.11
 Flask-WTF==0.14.2
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@39.5.0#egg=digitalmarketplace-utils==39.5.0
+git+https://github.com/alphagov/Flask-FeatureFlags.git@1.0#egg=Flask-FeatureFlags==1.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@40.6.0#egg=digitalmarketplace-utils==40.6.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.2.0#egg=digitalmarketplace-content-loader==4.2.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@17.2.0#egg=digitalmarketplace-apiclient==17.2.0
 
@@ -22,7 +23,6 @@ contextlib2==0.4.0
 cryptography==1.9
 docopt==0.4.0
 docutils==0.14
-Flask-FeatureFlags==0.6
 Flask-Script==2.0.6
 future==0.16.0
 idna==2.7


### PR DESCRIPTION
Trello: https://trello.com/c/9HOV64oh/362-external-route-failure-for-frameworkfamily-opportunities-when-frameworkfamily-suppliers

The URL should now 404 instead of raising a 'NotImplementedError' (tested locally, all seems fine).

Also adds the Flask-FeatureFlags dependency (as per utils v40).