### PR TITLE
Use external URL with framework.family

### DIFF
--- a/app/templates/frameworks/opportunities_dashboard.html
+++ b/app/templates/frameworks/opportunities_dashboard.html
@@ -34,7 +34,7 @@
     </div>
 
   <p>
-    <a href={{ "/{}/opportunities".format(framework.framework) }}>
+    <a href="{{ url_for('external.list_opportunities', framework_family=framework.family) }}">
       Search for other opportunities
     </a>
   </p>


### PR DESCRIPTION
Trello: https://trello.com/c/R3DsCXFa/22-use-frameworkfamily-frameworkfamily-in-apps-apiclient-rather-than-frameworkframework-frameworkframework

Only one usage of `framework.framework`, in a hardcoded URL. We can replace this with an external route, fix the quotes around the href value *and* switch to using `framework.family` in one nifty commit.