### PR TITLE
Utils error handlers and templates for Brief Responses

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,6 +1,6 @@
 import re
 
-from flask import Flask, request, redirect, session, abort, url_for
+from flask import Flask, request, redirect, session, abort
 from flask_login import LoginManager
 from flask_wtf.csrf import CSRFProtect, CSRFError
 

--- a/app/main/errors.py
+++ b/app/main/errors.py
@@ -1,76 +1,14 @@
-try:
-    from urllib import quote_plus
-except ImportError:
-    from urllib.parse import quote_plus
-from flask import redirect, render_template, request, url_for, session, current_app, flash
-from flask_wtf.csrf import CSRFError
 from app.main import main
 from dmapiclient import APIError
 from dmcontent.content_loader import QuestionNotFoundError
+from dmutils.errors import render_error_page
 
 
 @main.app_errorhandler(APIError)
 def api_error_handler(e):
-    return _render_error_page(e.status_code)
+    return render_error_page(e)
 
 
 @main.app_errorhandler(QuestionNotFoundError)
 def content_loader_error_handler(e):
-    return _render_error_page(400)
-
-
-@main.app_errorhandler(401)
-def page_unauthorized(e):
-    if request.method == 'GET':
-        return redirect('/user/login?next={}'.format(quote_plus(request.path)))
-    else:
-        return redirect('/user/login')
-
-
-@main.app_errorhandler(404)
-def page_not_found(e):
-    return _render_error_page(404)
-
-
-@main.app_errorhandler(500)
-def internal_server_error(e):
-    return _render_error_page(500)
-
-
-@main.app_errorhandler(503)
-def service_unavailable(e):
-    return _render_error_page(503)
-
-
-@main.app_errorhandler(400)
-def csrf_handler(e):
-    # CSRFErrors seem to be propagated as '400 Bad Request' exceptions, which means Flask is looking for
-    # a 400 handler rather than a specific CSRFError handler.
-    # This heavy-handed solution therefore catches all 400s, but immediately discards non-CSRFError instances.
-    if not isinstance(e, CSRFError):
-        raise e
-
-    if 'user_id' not in session:
-        current_app.logger.info(
-            u'csrf.session_expired: Redirecting user to log in page'
-        )
-    else:
-        current_app.logger.info(
-            u'csrf.invalid_token: Aborting request, user_id: {user_id}',
-            extra={'user_id': session['user_id']}
-        )
-
-    flash('Your session has expired. Please log in again.', "error")
-    return redirect(url_for('external.render_login', next=request.path))
-
-
-def _render_error_page(status_code):
-    template_map = {
-        400: "errors/500.html",
-        404: "errors/404.html",
-        500: "errors/500.html",
-        503: "errors/500.html",
-    }
-    if status_code not in template_map:
-        status_code = 500
-    return render_template(template_map[status_code]), status_code
+    return render_error_page(400)

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "colors": "1.1.2",
     "jquery": "1.12.0",
     "hogan.js": "3.0.2",
-    "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v31.0.1",
+    "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v31.7.0",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.19.2/jinja_govuk_template-0.19.2.tgz",
     "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#13.1.0"
   },

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -6,6 +6,6 @@ Flask-Login==0.2.11
 Flask-WTF==0.14.2
 
 git+https://github.com/alphagov/Flask-FeatureFlags.git@1.0#egg=Flask-FeatureFlags==1.0
-git+https://github.com/alphagov/digitalmarketplace-utils.git@42.2.1#egg=digitalmarketplace-utils==42.2.1
+git+https://github.com/alphagov/digitalmarketplace-utils.git@42.4.0#egg=digitalmarketplace-utils==42.4.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.2.0#egg=digitalmarketplace-content-loader==4.2.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@19.0.0#egg=digitalmarketplace-apiclient==19.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ Flask-Login==0.2.11
 Flask-WTF==0.14.2
 
 git+https://github.com/alphagov/Flask-FeatureFlags.git@1.0#egg=Flask-FeatureFlags==1.0
-git+https://github.com/alphagov/digitalmarketplace-utils.git@42.2.1#egg=digitalmarketplace-utils==42.2.1
+git+https://github.com/alphagov/digitalmarketplace-utils.git@42.4.0#egg=digitalmarketplace-utils==42.4.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.2.0#egg=digitalmarketplace-content-loader==4.2.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@19.0.0#egg=digitalmarketplace-apiclient==19.0.0
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -523,9 +523,9 @@ detect-file@^1.0.0:
   version "13.1.0"
   resolved "https://github.com/alphagov/digitalmarketplace-frameworks.git#d51ee0b7c1751b0d08d6ddf14bd64d12b9783f57"
 
-"digitalmarketplace-frontend-toolkit@https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v31.0.1":
-  version "31.0.1"
-  resolved "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#b34e87bf0c1910f6c8d4ef86f1db9b6533423902"
+"digitalmarketplace-frontend-toolkit@https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v31.7.0":
+  version "31.7.0"
+  resolved "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#74459b8b9a5e8da35e967509ace77ceeedfd8e4a"
   dependencies:
     del "^2.2.2"
     govuk-elements-sass "3.0.3"


### PR DESCRIPTION
Trello: https://trello.com/c/kqjkCP72/101-move-csrf-session-expired-message-to-utils

Trying out the new error handling and templates in the Brief Responses FE.

I've added a couple of tests in `test_application` as examples to check that 1) the CSRF error handler is being invoked correctly 2) the 400.html toolkit template is being used. There are more comprehensive tests for each common exception class/error template in the utils repo.

