### PR TITLE
Catch BadRequest responses from API when submitting applications

### DIFF
--- a/app/main/views/briefs.py
+++ b/app/main/views/briefs.py
@@ -274,20 +274,20 @@ def check_brief_response_answers(brief_id, brief_response_id):
             )
             if submit_response['briefResponses'].get('status') == 'draft':
                 # DB returned 200 OK but failed to update for some reason
-                error_message = 'Please try again.'
+                error_message = 'There was a problem submitting your application.'
         except HTTPError as e:
             if e.status_code != 400:
                 # Unexpected error
                 raise
             if any(v == 'answer_required' for v in e.message.values()):
                 # Missing section
-                error_message = 'Please complete all the required sections.'
+                error_message = 'You need to complete all the sections before you can submit your application.'
             else:
                 # Some other bad request
-                error_message = 'Please check your answers and try again.'
+                error_message = 'There was a problem submitting your application.'
 
         if error_message:
-            flash("There was a problem submitting your application. {}".format(error_message), 'error')
+            flash(error_message, 'error')
         else:
             flash(APPLICATION_SUBMITTED_FIRST_MESSAGE)
             # To trigger the analytics Virtual Page View

--- a/tests/app/main/test_briefs.py
+++ b/tests/app/main/test_briefs.py
@@ -2045,9 +2045,24 @@ class TestResponseResultPage(BaseApplicationTest, BriefResponseTestHelpers):
     @pytest.mark.parametrize(
         'response_msg, response_status_code, expected_error_message, expected_status_code',
         [
-            ({'essentialRequirements': 'answer_required'}, 400, 'Please complete all the required sections.', 200),
-            ({'essentialRequirements': 'different_error'}, 400, 'Please check your answers and try again.', 200),
-            ("Ragnarok", 500, "Sorry, we’re experiencing technical difficulties", 500),
+            (
+                {'essentialRequirements': 'answer_required'},
+                400,
+                'You need to complete all the sections before you can submit your application.',
+                200
+            ),
+            (
+                {'essentialRequirements': 'different_error'},
+                400,
+                'There was a problem submitting your application.',
+                200
+            ),
+            (
+                "Ragnarok",
+                500,
+                "Sorry, we’re experiencing technical difficulties",
+                500
+            ),
         ]
     )
     def test_error_message_shown_for_exceptions_when_submitting_application(
@@ -2102,7 +2117,7 @@ class TestResponseResultPage(BaseApplicationTest, BriefResponseTestHelpers):
         data = res.get_data(as_text=True)
 
         # Error flash message should be shown
-        assert 'There was a problem submitting your application. Please try again.' in data
+        assert 'There was a problem submitting your application.' in data
 
     def test_analytics_and_messages_applied_on_first_submission(self):
         """Go through submitting to edit_brief_response and the redirect to view_response_result. Assert messages."""


### PR DESCRIPTION
Trello: https://trello.com/c/Virw5sGZ/114-500-error-question-not-found

![brief-resp-error](https://user-images.githubusercontent.com/3492540/44340046-7a06d180-a47b-11e8-9a5e-dd5ebfd7225c.png)

If a supplier tries to submit a partially completed application, they are currently redirected to a generic 400 template, without any advice on how to fix the problem. 

There is no form to validate/grab formatted errors from, so we need to handle the possible error cases in a crude way, generating slightly less vague error messages:

- missing fields (400, the most likely occurrence)
- some other 400 (e.g. invalid date - should be picked up by form validation before this point)
- DB didn't update, so the status is still 'draft' (returned as a 200 OK)
- Something else (raise as a normal exception)

This seems like the quickest way to mitigate the problem for now - thoughts on better ways to do it welcome.

NB: I haven't checked the content with anyone yet 😸 