### PR TITLE
Brief Responses FE errors: pass status code to error handler as a kwarg

### DIFF
--- a/app/main/errors.py
+++ b/app/main/errors.py
@@ -6,9 +6,9 @@ from dmutils.errors import render_error_page
 
 @main.app_errorhandler(APIError)
 def api_error_handler(e):
-    return render_error_page(e)
+    return render_error_page(status_code=e.status_code)
 
 
 @main.app_errorhandler(QuestionNotFoundError)
 def content_loader_error_handler(e):
-    return render_error_page(400)
+    return render_error_page(status_code=400)


### PR DESCRIPTION
Another error handling fix (see https://github.com/alphagov/digitalmarketplace-buyer-frontend/pull/828)

For this one, passing the `APIError` exception to `render_error_page` is actually correct, however I've changed it to just use the status code to be consistent with the other apps.

