### PR TITLE
Update forms to use dmutils@42.x.x features

### DIFF
--- a/app/main/forms/briefs.py
+++ b/app/main/forms/briefs.py
@@ -1,27 +1,35 @@
-from flask import escape, Markup
+from flask import Markup
 from flask_wtf import FlaskForm
 from wtforms import validators
 
+from dmutils.formats import dateformat
 from dmutils.forms.fields import DMStripWhitespaceStringField
+from dmutils.forms.widgets import DMTextArea
 
 
 class AskClarificationQuestionForm(FlaskForm):
     """Form for a supplier to ask a clarification question about a given brief."""
     clarification_question = DMStripWhitespaceStringField(
-        label="Ask a question",
+        "Ask a question about ‘{brief[title]}’",
+        question_advice=(
+            """
+            Your question will be published with the buyer’s answer by {submission_deadline}.
+            All questions and answers will be posted on the Digital Marketplace. Your company name won’t be visible.
+            You shouldn’t include any confidential information in your question.
+            Read more about <a href="{guidance_url}">how supplier questions are managed</a>.
+            """
+        ),
         validators=[validators.DataRequired(message='Question cannot be empty'),
                     validators.Length(max=5000, message='Question cannot be longer than 5000 characters'),
                     validators.Regexp(regex="^$|(^(?:\\S+\\s+){0,99}\\S+$)",
-                                      message='Question must be no more than 100 words')]
+                                      message='Question must be no more than 100 words')],
+        widget=DMTextArea(max_length_in_words=100),
     )
 
     def __init__(self, brief, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.clarification_question.label.text = Markup(f'Ask a question about ‘{escape(brief["title"])}’')
-        self.clarification_question.advice = (
-            'Your question will be published with the buyer’s answer by {}. All questions and answers will be posted '
-            'on the Digital Marketplace. Your company name won’t be visible. You shouldn’t include any confidential '
-            'information in your question. Read more about <a href="https://www.gov.uk/guidance/how-to-answer-supplier-'
-            'questions-about-your-digital-outcomes-and-specialists-requirements">how supplier questions are '
-            'managed</a>.'
-        )
+        self.clarification_question.question = self.clarification_question.question.format(brief=brief)
+        self.clarification_question.question_advice = Markup(self.clarification_question.question_advice.format(
+            submission_deadline=dateformat(brief['clarificationQuestionsPublishedBy']),
+            guidance_url="https://www.gov.uk/guidance/how-to-answer-supplier-questions-about-your-digital-outcomes-and-specialists-requirements",  # noqa
+        ))

--- a/app/templates/briefs/clarification_question.html
+++ b/app/templates/briefs/clarification_question.html
@@ -29,7 +29,7 @@
     <div class="column-two-thirds">
 
       {% with
-        heading = form.clarification_question.label.text,
+        heading = form.clarification_question.question,
         smaller = true
       %}
         {% include 'toolkit/page-heading.html' %}
@@ -37,17 +37,9 @@
 
       <form method="post">
         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
-        {%
-          with
-          large = true,
-          name = 'clarification_question',
-          question = form.clarification_question.label.text,
-          error = errors.get('clarification_question', {}).get('message', None),
-          max_length_in_words = 100,
-          question_advice = form.clarification_question.advice.format(brief.clarificationQuestionsPublishedBy|dateformat)|safe
-        %}
-          {% include "toolkit/forms/textbox.html" %}
-        {% endwith %}
+
+        {{ form.clarification_question }}
+
         {%
           with
           label="Ask question",

--- a/tests/app/main/test_briefs.py
+++ b/tests/app/main/test_briefs.py
@@ -226,6 +226,33 @@ class TestBriefClarificationQuestions(BaseApplicationTest):
         res = self.client.get('/suppliers/opportunities/1/ask-a-question')
         assert res.status_code == 404
 
+    def test_clarification_question_advice_shows_date_when_answers_will_be_published_by(self):
+        self.login()
+        brief = api_stubs.brief(status="live")
+        brief['briefs']['frameworkName'] = 'Brief Framework Name'
+        brief['briefs']['clarificationQuestionsPublishedBy'] = '2016-03-29T10:11:13.000000Z'
+        self.data_api_client.get_brief.return_value = brief
+
+        res = self.client.post('/suppliers/opportunities/1/ask-a-question')
+        xpath = html.fromstring(res.get_data(as_text=True)).xpath
+        advice = xpath("//*[@class='question-advice']/text()")[0]
+
+        assert "Tuesday 29 March 2016" in advice
+
+    def test_clarification_question_advice_includes_link_to_gov_uk_guidance(self):
+        self.login()
+        brief = api_stubs.brief(status="live")
+        brief['briefs']['frameworkName'] = 'Brief Framework Name'
+        brief['briefs']['clarificationQuestionsPublishedBy'] = '2016-03-29T10:11:13.000000Z'
+        self.data_api_client.get_brief.return_value = brief
+
+        res = self.client.post('/suppliers/opportunities/1/ask-a-question')
+        xpath = html.fromstring(res.get_data(as_text=True)).xpath
+
+        guidance_url = xpath("//*[@class='question-advice']//a/@href")[0]
+
+        assert guidance_url.startswith("https://www.gov.uk/guidance")
+
 
 class TestSubmitClarificationQuestions(BaseApplicationTest):
 


### PR DESCRIPTION
This PR closes https://trello.com/c/dpQKpIn2/106-refactor-brief-responses-frontend-to-use-new-dmutilsforms-features

It requires https://github.com/alphagov/digitalmarketplace-utils/pull/444 and https://github.com/alphagov/digitalmarketplace-utils/pull/445