### PR TITLE
Brief Responses FE: Update Flask-Login to v0.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "colors": "1.1.2",
     "jquery": "1.12.0",
     "hogan.js": "3.0.2",
-    "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v31.7.0",
+    "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v31.8.0",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.19.2/jinja_govuk_template-0.19.2.tgz",
     "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#13.1.0"
   },

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -2,7 +2,7 @@
 # with package version changes made in requirements-app.txt
 
 Flask==0.12.4
-Flask-Login==0.2.11
+Flask-Login==0.4.1
 Flask-WTF==0.14.2
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@43.0.0#egg=digitalmarketplace-utils==43.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@
 # with package version changes made in requirements-app.txt
 
 Flask==0.12.4
-Flask-Login==0.2.11
+Flask-Login==0.4.1
 Flask-WTF==0.14.2
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@43.0.0#egg=digitalmarketplace-utils==43.0.0
@@ -14,7 +14,7 @@ git+https://github.com/alphagov/digitalmarketplace-apiclient.git@19.0.0#egg=digi
 asn1crypto==0.24.0
 boto3==1.4.8
 botocore==1.8.50
-certifi==2018.8.13
+certifi==2018.8.24
 cffi==1.11.5
 chardet==3.0.4
 click==6.7

--- a/yarn.lock
+++ b/yarn.lock
@@ -523,9 +523,9 @@ detect-file@^1.0.0:
   version "13.1.0"
   resolved "https://github.com/alphagov/digitalmarketplace-frameworks.git#d51ee0b7c1751b0d08d6ddf14bd64d12b9783f57"
 
-"digitalmarketplace-frontend-toolkit@https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v31.7.0":
-  version "31.7.0"
-  resolved "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#74459b8b9a5e8da35e967509ace77ceeedfd8e4a"
+"digitalmarketplace-frontend-toolkit@https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v31.8.0":
+  version "31.8.0"
+  resolved "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#b30b2ad578d56e17889ce86a0004ee77db047751"
   dependencies:
     del "^2.2.2"
     govuk-elements-sass "3.0.3"


### PR DESCRIPTION
Trello: https://trello.com/c/euSnpBnN/65-update-flask-login

- Update the Flask Login version
- Pull in related FE toolkit changes

No breaking changes to address for this app.