### PR TITLE
digitalmarketplace-apiclient dependency: bump to 19.7.0 for new timeout behaviour

### DIFF
--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -7,4 +7,4 @@ Flask-WTF==0.14.2
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@44.0.1#egg=digitalmarketplace-utils==44.0.1
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@5.0.0#egg=digitalmarketplace-content-loader==5.0.0
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@19.4.0#egg=digitalmarketplace-apiclient==19.4.0
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@19.7.0#egg=digitalmarketplace-apiclient==19.7.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,16 +8,16 @@ Flask-WTF==0.14.2
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@44.0.1#egg=digitalmarketplace-utils==44.0.1
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@5.0.0#egg=digitalmarketplace-content-loader==5.0.0
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@19.4.0#egg=digitalmarketplace-apiclient==19.4.0
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@19.7.0#egg=digitalmarketplace-apiclient==19.7.0
 
 ## The following requirements were added by pip freeze:
 asn1crypto==0.24.0
 boto3==1.7.83
 botocore==1.10.84
-certifi==2018.8.24
+certifi==2018.10.15
 cffi==1.11.5
 chardet==3.0.4
-click==6.7
+Click==7.0
 contextlib2==0.4.0
 cryptography==2.3
 docopt==0.4.0
@@ -26,7 +26,7 @@ Flask-Script==2.0.6
 future==0.16.0
 idna==2.7
 inflection==0.3.1
-itsdangerous==0.24
+ItsDangerous==1.0.0
 Jinja2==2.10
 jmespath==0.9.3
 mailchimp3==2.0.11
@@ -36,17 +36,17 @@ MarkupSafe==1.0
 monotonic==0.3
 notifications-python-client==4.1.0
 odfpy==1.3.6
-pycparser==2.18
+pycparser==2.19
 PyJWT==1.6.4
 python-dateutil==2.7.3
 python-json-logger==0.1.4
 pytz==2015.4
 PyYAML==3.11
-requests==2.19.1
+requests==2.20.0
 s3transfer==0.1.13
 six==1.11.0
 unicodecsv==0.14.1
-urllib3==1.23
+urllib3==1.24
 Werkzeug==0.14.1
 workdays==1.4
 WTForms==2.2.1


### PR DESCRIPTION
New soup of random versions for ya.

Should hopefully mitigate https://trello.com/c/IAATy1vP/451-curious-2-minute-api-timeouts