### PR TITLE
Use API stubs in Brief responses FE

### DIFF
--- a/config.py
+++ b/config.py
@@ -63,7 +63,7 @@ class Test(Config):
     DM_PLAIN_TEXT_LOGS = True
     DM_LOG_LEVEL = 'CRITICAL'
     WTF_CSRF_ENABLED = False
-    SERVER_NAME = 'localhost'
+    SERVER_NAME = 'localhost.localdomain'
     DM_NOTIFY_API_KEY = 'not_a_real_key'
     SECRET_KEY = 'verySecretKey'
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -12,4 +12,4 @@ python-coveralls==2.5.0
 requests-mock==0.6.0
 watchdog==0.8.3
 
-git+https://github.com/alphagov/digitalmarketplace-test-utils.git@1.2.0#egg=digitalmarketplace-test-utils==1.2.0
+git+https://github.com/alphagov/digitalmarketplace-test-utils.git@2.1.2#egg=digitalmarketplace-test-utils==2.1.2

--- a/tests/app/main/test_briefs.py
+++ b/tests/app/main/test_briefs.py
@@ -525,7 +525,7 @@ class TestApplyToBrief(BaseApplicationTest):
 
         res = self.client.get('/suppliers/opportunities/1234/responses/5')
         assert res.status_code == 302
-        assert res.location == 'http://localhost/suppliers/opportunities/1234/responses/5/first'
+        assert res.location == 'http://localhost.localdomain/suppliers/opportunities/1234/responses/5/first'
 
     def test_can_get_question_page_for_live_and_expired_framework(self):
         for framework_status in ['live', 'expired']:
@@ -546,7 +546,7 @@ class TestApplyToBrief(BaseApplicationTest):
             res = self.client.post('/suppliers/opportunities/1234/responses/5/respondToEmailAddress')
 
             assert res.status_code == 302
-            assert res.location == 'http://localhost/suppliers/opportunities/1234/responses/5/application'
+            assert res.location == 'http://localhost.localdomain/suppliers/opportunities/1234/responses/5/application'
 
     def test_can_get_question_page_when_editing_for_live_and_expired_framework(self):
         self.data_api_client.find_brief_responses.return_value = {"briefResponses": [{"yay": "hey"}]}
@@ -569,7 +569,7 @@ class TestApplyToBrief(BaseApplicationTest):
             res = self.client.post('/suppliers/opportunities/1234/responses/5/respondToEmailAddress/edit')
 
             assert res.status_code == 302
-            assert res.location == 'http://localhost/suppliers/opportunities/1234/responses/5/application'
+            assert res.location == 'http://localhost.localdomain/suppliers/opportunities/1234/responses/5/application'
 
     def test_404_if_brief_response_does_not_exist(self):
         for method in ('get', 'post'):
@@ -1046,7 +1046,7 @@ class TestApplyToBrief(BaseApplicationTest):
         )
 
         assert res.status_code == 302
-        assert res.location == 'http://localhost/suppliers/opportunities/1234/responses/5/respondToEmailAddress'
+        assert res.location == 'http://localhost.localdomain/suppliers/opportunities/1234/responses/5/respondToEmailAddress'  # noqa
 
     def test_nice_to_have_requirements_url_404s_if_no_nice_to_have_requirements(self):
         self.brief['briefs']['niceToHaveRequirements'] = []
@@ -1258,7 +1258,7 @@ class TestApplyToBrief(BaseApplicationTest):
             page_questions=['dayRate']
         )
 
-        assert res.location == 'http://localhost/suppliers/opportunities/1234/responses/5/essentialRequirementsMet'
+        assert res.location == 'http://localhost.localdomain/suppliers/opportunities/1234/responses/5/essentialRequirementsMet'  # noqa
 
     def test_post_final_section_submits_response_redirects_to_check_your_answers_page(self):
         data = {'respondToEmailAddress': 'bob@example.com'}
@@ -1275,7 +1275,7 @@ class TestApplyToBrief(BaseApplicationTest):
             page_questions=['respondToEmailAddress']
         )
 
-        assert res.location == 'http://localhost/suppliers/opportunities/1234/responses/5/application'
+        assert res.location == 'http://localhost.localdomain/suppliers/opportunities/1234/responses/5/application'
         self.assert_no_flashes()
 
     def test_post_check_your_answers_page_submits_and_redirects_to_result_page(self):
@@ -1289,7 +1289,7 @@ class TestApplyToBrief(BaseApplicationTest):
             5,
             'email@email.com',
         )
-        assert res.location == 'http://localhost/suppliers/opportunities/1234/responses/result'
+        assert res.location == 'http://localhost.localdomain/suppliers/opportunities/1234/responses/result'
         self.assert_flashes("Your application has been submitted.")
 
     def test_editing_previously_completed_section_redirects_to_check_your_answers(self):
@@ -1306,7 +1306,7 @@ class TestApplyToBrief(BaseApplicationTest):
             page_questions=['dayRate']
         )
         assert res.status_code == 302
-        assert res.location == "http://localhost/suppliers/opportunities/1234/responses/5/application"
+        assert res.location == "http://localhost.localdomain/suppliers/opportunities/1234/responses/5/application"
         self.assert_flashes("Your application has been updated.")
 
 
@@ -1815,7 +1815,7 @@ class TestStartBriefResponseApplication(BaseApplicationTest, BriefResponseTestHe
         }
         res = self.client.get('/suppliers/opportunities/1234/responses/start')
         assert res.status_code == 302
-        assert res.location == 'http://localhost/suppliers/opportunities/1234/responses/5/application'
+        assert res.location == 'http://localhost.localdomain/suppliers/opportunities/1234/responses/5/application'
 
     def test_start_page_for_specialist_brief_shows_specialist_content(self):
         self.data_api_client.get_brief.return_value = self.brief
@@ -1913,7 +1913,7 @@ class TestPostStartBriefResponseApplication(BaseApplicationTest):
         res = self.client.post('/suppliers/opportunities/1234/responses/start')
         self.data_api_client.create_brief_response.assert_called_once_with(1234, 1234, {}, "email@email.com")
         assert res.status_code == 302
-        assert res.location == 'http://localhost/suppliers/opportunities/1234/responses/10'
+        assert res.location == 'http://localhost.localdomain/suppliers/opportunities/1234/responses/10'
 
     def test_redirects_to_beginning_of_ongoing_application_if_application_in_progress_but_not_submitted(self):
         self.data_api_client.get_brief.return_value = self.brief
@@ -1929,7 +1929,7 @@ class TestPostStartBriefResponseApplication(BaseApplicationTest):
         res = self.client.post('/suppliers/opportunities/1234/responses/start')
         self.data_api_client.create_brief_response.assert_not_called()
         assert res.status_code == 302
-        assert res.location == 'http://localhost/suppliers/opportunities/1234/responses/11'
+        assert res.location == 'http://localhost.localdomain/suppliers/opportunities/1234/responses/11'
 
     def test_redirects_to_response_page_with_flash_message_if_application_already_submitted(self):
         self.data_api_client.get_brief.return_value = self.brief
@@ -1945,7 +1945,7 @@ class TestPostStartBriefResponseApplication(BaseApplicationTest):
         res = self.client.post('/suppliers/opportunities/1234/responses/start')
         self.data_api_client.create_brief_response.assert_not_called()
         assert res.status_code == 302
-        assert res.location == 'http://localhost/suppliers/opportunities/1234/responses/5/application'
+        assert res.location == 'http://localhost.localdomain/suppliers/opportunities/1234/responses/5/application'
 
 
 class TestResponseResultPage(BaseApplicationTest, BriefResponseTestHelpers):
@@ -2188,7 +2188,7 @@ class TestResponseResultPage(BaseApplicationTest, BriefResponseTestHelpers):
         res = self.client.get('/suppliers/opportunities/1234/responses/result')
 
         assert res.status_code == 302
-        assert res.location == 'http://localhost/suppliers/opportunities/1234/responses/start'
+        assert res.location == 'http://localhost.localdomain/suppliers/opportunities/1234/responses/start'
 
     def test_view_response_result_draft_application_redirect_to_check_your_answers_page(self):
         self.set_framework_and_eligibility_for_api_client()
@@ -2202,7 +2202,7 @@ class TestResponseResultPage(BaseApplicationTest, BriefResponseTestHelpers):
         res = self.client.get('/suppliers/opportunities/1234/responses/result')
 
         assert res.status_code == 302
-        assert res.location == 'http://localhost/suppliers/opportunities/1234/responses/999/application'
+        assert res.location == 'http://localhost.localdomain/suppliers/opportunities/1234/responses/999/application'
 
     @mock.patch("app.main.views.briefs.is_supplier_eligible_for_brief")
     def test_view_result_legacy_flow_redirects_to_check_your_answer(self, is_supplier_eligible_for_brief):
@@ -2219,7 +2219,7 @@ class TestResponseResultPage(BaseApplicationTest, BriefResponseTestHelpers):
         res = self.client.get('/suppliers/opportunities/1234/responses/result')
 
         assert res.status_code == 302
-        assert res.location == "http://localhost/suppliers/opportunities/1234/responses/999/application"
+        assert res.location == "http://localhost.localdomain/suppliers/opportunities/1234/responses/999/application"
 
 
 @mock.patch("app.main.views.briefs.current_user")
@@ -2354,7 +2354,7 @@ class TestRedirectToPublicOpportunityPage(BaseApplicationTest):
         resp = self.client.get('suppliers/opportunities/{}'.format(brief_id))
 
         assert resp.status_code == 302
-        assert resp.location == 'http://localhost/digital-outcomes-and-specialists/opportunities/{}'.format(brief_id)
+        assert resp.location == 'http://localhost.localdomain/digital-outcomes-and-specialists/opportunities/{}'.format(brief_id)  # noqa
 
     def test_suppliers_opportunity_brief_id_404s_if_brief_not_found(self):
         self.data_api_client.get_brief.side_effect = HTTPError(mock.Mock(status_code=404))

--- a/tests/app/main/test_metrics.py
+++ b/tests/app/main/test_metrics.py
@@ -2,7 +2,7 @@
 import mock
 import re
 
-from dmutils import api_stubs
+from dmtestutils.api_model_stubs import BriefStub
 
 from tests.app.helpers import BaseApplicationTest
 
@@ -47,7 +47,7 @@ class TestMetricsPageRegistersPageViews(BaseApplicationTest):
         )
 
         self.login()
-        self.data_api_client.get_brief.return_value = api_stubs.brief(status='live')
+        self.data_api_client.get_brief.return_value = BriefStub(status='live').single_result_response()
 
         res = self.client.get('/suppliers/opportunities/1/question-and-answer-session')
         assert res.status_code == 200
@@ -68,7 +68,7 @@ class TestMetricsPageRegistersPageViews(BaseApplicationTest):
         initial_metric_value = int(initial_results.get(expected_metric_name, 0))
 
         self.login()
-        self.data_api_client.get_brief.return_value = api_stubs.brief(status='live')
+        self.data_api_client.get_brief.return_value = BriefStub(status='live').single_result_response()
 
         for _ in range(3):
             res = self.client.get('/suppliers/opportunities/1/question-and-answer-session')

--- a/tests/app/main/test_metrics.py
+++ b/tests/app/main/test_metrics.py
@@ -23,7 +23,7 @@ class TestMetricsPage(BaseApplicationTest):
         results = load_prometheus_metrics(metrics_response.data)
 
         assert (
-            b'http_server_requests_total{code="200",host="localhost",method="GET",'
+            b'http_server_requests_total{code="200",host="localhost.localdomain",method="GET",'
             b'path="/suppliers/opportunities/metrics"}'
         ) in results
 
@@ -41,7 +41,8 @@ class TestMetricsPageRegistersPageViews(BaseApplicationTest):
 
     def test_metrics_page_registers_page_views(self):
         expected_metric_name = (
-            b'http_server_requests_total{code="200",host="localhost",method="GET",path="/suppliers/opportunities/'
+            b'http_server_requests_total{code="200",host="localhost.localdomain",'
+            b'method="GET",path="/suppliers/opportunities/'
             b'<int:brief_id>/question-and-answer-session"}'
         )
 
@@ -57,7 +58,8 @@ class TestMetricsPageRegistersPageViews(BaseApplicationTest):
 
     def test_metrics_page_registers_multiple_page_views(self):
         expected_metric_name = (
-            b'http_server_requests_total{code="200",host="localhost",method="GET",path="/suppliers/opportunities/'
+            b'http_server_requests_total{code="200",host="localhost.localdomain",'
+            b'method="GET",path="/suppliers/opportunities/'
             b'<int:brief_id>/question-and-answer-session"}'
         )
 

--- a/tests/app/test_application.py
+++ b/tests/app/test_application.py
@@ -32,7 +32,7 @@ class TestApplication(BaseApplicationTest):
     def test_url_with_non_canonical_trailing_slash(self):
         response = self.client.get('/suppliers/opportunities/')
         assert response.status_code == 301
-        assert "http://localhost/suppliers/opportunities" == response.location
+        assert "http://localhost.localdomain/suppliers/opportunities" == response.location
 
     @mock.patch('app.main.briefs.get_brief')
     def test_400(self, get_brief):
@@ -104,5 +104,5 @@ class TestApplication(BaseApplicationTest):
             assert res.status_code == 302
 
             # POST requests will not preserve the request path on redirect
-            assert res.location == 'http://localhost/user/login'
+            assert res.location == 'http://localhost.localdomain/user/login'
             assert validate_csrf.call_args_list == [mock.call(None)]

--- a/tests/app/test_application.py
+++ b/tests/app/test_application.py
@@ -4,7 +4,7 @@ import mock
 from wtforms import ValidationError
 from werkzeug.exceptions import BadRequest
 from .helpers import BaseApplicationTest
-from dmutils import api_stubs
+from dmtestutils.api_model_stubs import BriefStub
 from dmapiclient.errors import HTTPError
 
 
@@ -13,7 +13,7 @@ class TestApplication(BaseApplicationTest):
         super().setup_method(method)
         self.data_api_client_patch = mock.patch('app.main.views.briefs.data_api_client')
         self.data_api_client = self.data_api_client_patch.start()
-        self.data_api_client.get_brief.return_value = api_stubs.brief(status='live')
+        self.data_api_client.get_brief.return_value = BriefStub(status='live').single_result_response()
         self.login()
 
     def teardown_method(self, method):
@@ -66,7 +66,7 @@ class TestApplication(BaseApplicationTest):
 
     def test_header_xframeoptions_set_to_deny(self):
         self.login()
-        self.data_api_client.get_brief.return_value = api_stubs.brief(status='live')
+        self.data_api_client.get_brief.return_value = BriefStub(status='live').single_result_response()
 
         res = self.client.get('/suppliers/opportunities/1/ask-a-question')
         assert res.status_code == 200
@@ -74,7 +74,7 @@ class TestApplication(BaseApplicationTest):
 
     def test_should_use_local_cookie_page_on_cookie_message(self):
         self.login()
-        self.data_api_client.get_brief.return_value = api_stubs.brief(status='live')
+        self.data_api_client.get_brief.return_value = BriefStub(status='live').single_result_response()
 
         res = self.client.get('/suppliers/opportunities/1/ask-a-question')
         assert res.status_code == 200


### PR DESCRIPTION
Trello: https://trello.com/c/NoQTjy3w/316-pull-in-api-stubs-to-apps

Straightforward for this repo. Note that we don't have a BriefResponse stub yet.

I was getting a bunch of warnings from flask.sessions because we use `localhost` a lot in our tests - it's not a valid cookie domain so it suggested using `localhost.localdomain` instead (but only on the test config, so we don't have to faff around with hosts files etc in development). If anyone feels strongly that we should use localdomain in the `Development` config as well, or nowhere at all, shout now!