### PR TITLE
 brief response submission: make POST requests behave slightly more sanely when failing

### DIFF
--- a/app/main/views/briefs.py
+++ b/app/main/views/briefs.py
@@ -309,7 +309,7 @@ def check_brief_response_answers(brief_id, brief_response_id):
         brief=brief,
         brief_response=brief_response,
         response_content=response_content
-    )
+    ), 200 if error_message is None else 400
 
 
 @main.route('/<int:brief_id>/responses/result')

--- a/tests/app/main/test_briefs.py
+++ b/tests/app/main/test_briefs.py
@@ -1537,10 +1537,17 @@ class TestCheckYourAnswers(BaseApplicationTest):
         )
         assert len(view_opportunity_links) == 0
 
+    @pytest.mark.parametrize('brief_response_status', ['draft', 'submitted'])
     @pytest.mark.parametrize('brief_status', ['closed', 'awarded', 'cancelled', 'unsuccessful'])
-    def test_check_your_answers_hides_submit_button_and_closing_date_for_non_live_briefs(self, brief_status):
+    def test_check_your_answers_hides_submit_button_and_closing_date_for_non_live_briefs(
+        self,
+        brief_status,
+        brief_response_status,
+    ):
         self.brief['briefs']['status'] = brief_status
-        self.data_api_client.get_brief_response.return_value = self.brief_response(data={'status': 'submitted'})
+        self.data_api_client.get_brief_response.return_value = self.brief_response(
+            data={'status': brief_response_status},
+        )
 
         res = self.client.get('/suppliers/opportunities/1234/responses/5/application')
         doc = html.fromstring(res.get_data(as_text=True))
@@ -2101,6 +2108,12 @@ class TestResponseResultPage(BaseApplicationTest, BriefResponseTestHelpers):
                 200
             ),
             (
+                "Hoddmimis",
+                400,
+                'There was a problem submitting your application.',
+                200
+            ),
+            (
                 "Ragnarok",
                 500,
                 "Sorry, we’re experiencing technical difficulties",
@@ -2161,6 +2174,37 @@ class TestResponseResultPage(BaseApplicationTest, BriefResponseTestHelpers):
 
         # Error flash message should be shown
         assert 'There was a problem submitting your application.' in data
+
+    @pytest.mark.parametrize('brief_status', ['closed', 'awarded', 'cancelled', 'unsuccessful'])
+    def test_submit_to_already_closed_brief(self, brief_status):
+        self.set_framework_and_eligibility_for_api_client()
+        self.brief['briefs']['status'] = brief_status
+        self.data_api_client.get_brief.return_value = self.brief
+        self.data_api_client.get_brief_response.return_value = self.brief_response()
+        self.data_api_client.find_brief_responses.return_value = {
+            'briefResponses': [self.brief_response(data={'essentialRequirementsMet': True})['briefResponses']]
+        }
+        self.data_api_client.is_supplier_eligible_for_brief.return_value = True
+
+        res = self.client.post(
+            '/suppliers/opportunities/{brief_id}/responses/{brief_response_id}/application'.format(
+                brief_id=self.brief['briefs']['id'],
+                brief_response_id=self.brief_response()['briefResponses']['id'],
+            ),
+            data={}
+        )
+        assert res.status_code == 200
+        data = res.get_data(as_text=True)
+        doc = html.fromstring(data)
+
+        # Error flash message should be shown
+        assert doc.xpath(
+            "//*[contains(@class, 'banner-destructive-without-action')][normalize-space(string())=$t]",
+            t="This opportunity has already closed for applications.",
+        )
+
+        # view shouldn't have bothered calling this
+        assert self.data_api_client.submit_brief_response.called is False
 
     def test_analytics_and_messages_applied_on_first_submission(self):
         """Go through submitting to edit_brief_response and the redirect to view_response_result. Assert messages."""

--- a/tests/app/main/test_briefs.py
+++ b/tests/app/main/test_briefs.py
@@ -2099,19 +2099,19 @@ class TestResponseResultPage(BaseApplicationTest, BriefResponseTestHelpers):
                 {'essentialRequirements': 'answer_required'},
                 400,
                 'You need to complete all the sections before you can submit your application.',
-                200
+                400
             ),
             (
                 {'essentialRequirements': 'different_error'},
                 400,
                 'There was a problem submitting your application.',
-                200
+                400
             ),
             (
                 "Hoddmimis",
                 400,
                 'There was a problem submitting your application.',
-                200
+                400
             ),
             (
                 "Ragnarok",
@@ -2169,7 +2169,7 @@ class TestResponseResultPage(BaseApplicationTest, BriefResponseTestHelpers):
             ),
             data={}
         )
-        assert res.status_code == 200  # No redirect
+        assert res.status_code == 400  # No redirect
         data = res.get_data(as_text=True)
 
         # Error flash message should be shown
@@ -2193,7 +2193,7 @@ class TestResponseResultPage(BaseApplicationTest, BriefResponseTestHelpers):
             ),
             data={}
         )
-        assert res.status_code == 200
+        assert res.status_code == 400
         data = res.get_data(as_text=True)
         doc = html.fromstring(data)
 


### PR DESCRIPTION
See https://trello.com/c/4OcRuemU

These are some delicate lines because they are the ones that govern what happens when people submit (or _think_ they submit) brief responses, so please check for any mistakes I may have made.

In this new behaviour, when we receive a submission `POST` request, note _first_ whether the brief is already closed (rather than waiting for an API failure and having to interpret its error message) - in which case give a clearer error message of "This opportunity has already closed for applications." (message ok'd by stefan) rather than the previous and rather open-ended generic "There was a problem submitting your application.". While we're at it, read 400 error messages from the API in a more foolproof way, so these don't get escalated to a 500 if the message is in an unexpected format, which is what was happening previously when submission to a closed brief was attempted.

_Now_, we should only get this response in cases where the brief closed **during** the course of the request, in which case we will fall back to the generic "There was a problem submitting your application.". But this should be an extremely rare circumstance, so that's probably ok.

I also pushed on top of this a change to make these failure pages return a 400 status code when they themselves received a 400 from the API, which I think is more in line with what we do elsewhere.