### PR TITLE
Bump digitalmarketplace-utils dependency to v48.2.0

### DIFF
--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -8,6 +8,6 @@ itsdangerous==0.24 # pyup: ignore
 
 gds-metrics==0.2.0
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@46.3.1#egg=digitalmarketplace-utils==46.3.1
-git+https://github.com/alphagov/digitalmarketplace-content-loader.git@5.2.0#egg=digitalmarketplace-content-loader==5.2.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@48.2.0#egg=digitalmarketplace-utils==48.2.0
+git+https://github.com/alphagov/digitalmarketplace-content-loader.git@5.2.1#egg=digitalmarketplace-content-loader==5.2.1
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@19.15.1#egg=digitalmarketplace-apiclient==19.15.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,22 +9,22 @@ itsdangerous==0.24 # pyup: ignore
 
 gds-metrics==0.2.0
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@46.3.1#egg=digitalmarketplace-utils==46.3.1
-git+https://github.com/alphagov/digitalmarketplace-content-loader.git@5.2.0#egg=digitalmarketplace-content-loader==5.2.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@48.2.0#egg=digitalmarketplace-utils==48.2.0
+git+https://github.com/alphagov/digitalmarketplace-content-loader.git@5.2.1#egg=digitalmarketplace-content-loader==5.2.1
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@19.15.1#egg=digitalmarketplace-apiclient==19.15.1
 
 ## The following requirements were added by pip freeze:
 asn1crypto==0.24.0
 blinker==1.4
-boto3==1.9.116
-botocore==1.12.116
+boto3==1.9.134
+botocore==1.12.134
 certifi==2019.3.9
-cffi==1.12.2
+cffi==1.12.3
 chardet==3.0.4
 Click==7.0
 contextlib2==0.5.5
 cryptography==2.3.1
-defusedxml==0.5.0
+defusedxml==0.6.0
 docopt==0.6.2
 docutils==0.14
 Flask-Script==2.0.6
@@ -33,7 +33,7 @@ future==0.17.1
 govuk-country-register==0.3.0
 idna==2.8
 inflection==0.3.1
-Jinja2==2.10
+Jinja2==2.10.1
 jmespath==0.9.4
 mailchimp3==3.0.6
 Markdown==2.6.11
@@ -45,14 +45,14 @@ prometheus-client==0.2.0
 pycparser==2.19
 PyJWT==1.7.1
 python-dateutil==2.8.0
-python-json-logger==0.1.10
-pytz==2018.9
+python-json-logger==0.1.11
+pytz==2019.1
 PyYAML==3.13
 requests==2.21.0
 s3transfer==0.2.0
 six==1.12.0
 unicodecsv==0.14.1
-urllib3==1.24.1
-Werkzeug==0.14.1
+urllib3==1.24.2
+Werkzeug==0.15.2
 workdays==1.4
 WTForms==2.2.1


### PR DESCRIPTION
Also bump digitalmarketplace-content-loader to 5.2.1 and other version
bumps that come with the re-freeze. This includes werkzeug 0.15.

This principally brings us the last-ditch exception logging.