### PR TITLE
FE toolkit error pages

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "colors": "1.1.2",
     "jquery": "1.12.0",
     "hogan.js": "3.0.2",
-    "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v33.0.0",
+    "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v34.1.0",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.19.2/jinja_govuk_template-0.19.2.tgz",
     "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#16.0.10"
   },

--- a/tests/app/test_application.py
+++ b/tests/app/test_application.py
@@ -50,10 +50,10 @@ class TestApplication(BaseApplicationTest):
         assert u"Check you’ve entered the correct web " \
             u"address or start again on the Digital Marketplace homepage." in res.get_data(as_text=True)
         assert u"If you can’t find what you’re looking for, contact us at " \
-            u"<a href=\"mailto:enquiries@digitalmarketplace.service.gov.uk?" \
+            u"<a href=\"mailto:cloud_digital@crowncommercial.gov.uk?" \
             u"subject=Digital%20Marketplace%20feedback\" title=\"Please " \
-            u"send feedback to enquiries@digitalmarketplace.service.gov.uk\">" \
-            u"enquiries@digitalmarketplace.service.gov.uk</a>" in res.get_data(as_text=True)
+            u"send feedback to cloud_digital@crowncommercial.gov.uk\">" \
+            u"cloud_digital@crowncommercial.gov.uk</a>" in res.get_data(as_text=True)
 
     def test_503(self):
         self.data_api_client.get_brief.side_effect = HTTPError('API is down')

--- a/yarn.lock
+++ b/yarn.lock
@@ -823,9 +823,9 @@ detect-libc@^1.0.2:
   version "16.0.10"
   resolved "https://github.com/alphagov/digitalmarketplace-frameworks.git#960bc2709719ee31e77a5bbe4503de6a846d23ae"
 
-"digitalmarketplace-frontend-toolkit@https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v33.0.0":
-  version "33.0.0"
-  resolved "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#87b965996196069d3ae7aeb55cc6cb9e3bcb0127"
+"digitalmarketplace-frontend-toolkit@https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v34.1.0":
+  version "34.1.0"
+  resolved "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#acb4f5e2b902df76d5517a37512980e8b911902a"
   dependencies:
     del "^4.1.0"
     govuk-elements-sass "3.0.3"


### PR DESCRIPTION
https://trello.com/c/3om47rfx/601-update-remaining-instances-of-enquiriesdigitalmarketplaceservicegovuk-to-the-new-support-address

Most of the 404 error pages fall through to the Buyer FE, which is showing the new support email address. But duff URLs served by the other FE apps (e.g. `/suppliers/opportunities/i-have-typed-this-url-badly`) haven't yet had the FE toolkit bumped.

The breaking change is for the reverted attempt to fix the JS for the functional tests.