### PR TITLE
Bump digitalmarketplace-utils dependency to 48.5.0

### DIFF
--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -8,6 +8,6 @@ itsdangerous==0.24 # pyup: ignore
 
 gds-metrics==0.2.0
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@48.2.0#egg=digitalmarketplace-utils==48.2.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@48.5.0#egg=digitalmarketplace-utils==48.5.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@6.0.0#egg=digitalmarketplace-content-loader==6.0.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@21.0.0#egg=digitalmarketplace-apiclient==21.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,15 +9,15 @@ itsdangerous==0.24 # pyup: ignore
 
 gds-metrics==0.2.0
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@48.2.0#egg=digitalmarketplace-utils==48.2.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@48.5.0#egg=digitalmarketplace-utils==48.5.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@6.0.0#egg=digitalmarketplace-content-loader==6.0.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@21.0.0#egg=digitalmarketplace-apiclient==21.0.0
 
 ## The following requirements were added by pip freeze:
 asn1crypto==0.24.0
 blinker==1.4
-boto3==1.9.210
-botocore==1.12.210
+boto3==1.9.214
+botocore==1.12.214
 certifi==2019.6.16
 cffi==1.12.3
 chardet==3.0.4


### PR DESCRIPTION
https://trello.com/c/HsZ9mj7o

bringing in "probe cookie"-setting, along with a re-freeze of dependencies