### PR TITLE
set DM_COOKIE_PROBE_COOKIE_EXPECT_PRESENT, enabling cookie error page

### DIFF
--- a/config.py
+++ b/config.py
@@ -18,6 +18,8 @@ class Config(object):
 
     PERMANENT_SESSION_LIFETIME = 3600  # 1 hour
 
+    DM_COOKIE_PROBE_COOKIE_EXPECT_PRESENT = True
+
     WTF_CSRF_ENABLED = True
     WTF_CSRF_TIME_LIMIT = None
 

--- a/default.nix
+++ b/default.nix
@@ -7,6 +7,17 @@ let
     forDev = true;
     localOverridesPath = ./local.nix;
   } // argsOuter;
+  sitePrioNonNix = args.pkgs.writeTextFile {
+    name = "site-prio-non-nix";
+    destination = "/${args.pythonPackages.python.sitePackages}/sitecustomize.py";
+    text = ''
+      import sys
+      first_nix_i = next((i for i, p in enumerate(sys.path) if p.startswith("/nix/")), 1)
+      # after the first nix-provided path in sys.path (presumably the python stdlib itself), re-sort all non-nix
+      # paths to be before the nix paths. this is helped by python's sort being a stable-sort
+      sys.path[first_nix_i+1:] = sorted(sys.path[first_nix_i+1:], key=lambda p: p.startswith("/nix/"))
+    '';
+  };
 in (with args; {
   digitalMarketplaceSupplierFrontendEnv = (pkgs.stdenv.mkDerivation rec {
     name = "digitalmarketplace-supplier-frontend-env";
@@ -15,6 +26,7 @@ in (with args; {
       nodejs = pkgs.nodejs-10_x;
     in [
       pythonPackages.python
+      sitePrioNonNix
       pkgs.glibcLocales
       nodejs
       (pkgs.yarn.override { inherit nodejs; })


### PR DESCRIPTION
https://trello.com/c/HsZ9mj7o

This should only ever show itself in place of a CSRF token failure, so should be a fairly safe thing to enable.