### PR TITLE
43-create-a-base-page-for-the-apps

### DIFF
--- a/app/templates/_base_page.html
+++ b/app/templates/_base_page.html
@@ -1,0 +1,3 @@
+{% extends "toolkit/layouts/_base_page.html" %}
+
+// Insert line for each component module import

--- a/app/templates/briefs/_base_edit_question_page.html
+++ b/app/templates/briefs/_base_edit_question_page.html
@@ -1,4 +1,4 @@
-{% extends "toolkit/layouts/_base_page.html" %}
+{% extends "_base_page.html" %}
 {% import "toolkit/forms/macros/forms.html" as forms %}
 
 {% block page_title %}{{ question.question }} – Digital Marketplace{% endblock %}

--- a/app/templates/briefs/application_submitted.html
+++ b/app/templates/briefs/application_submitted.html
@@ -1,4 +1,4 @@
-{% extends "toolkit/layouts/_base_page.html" %}
+{% extends "_base_page.html" %}
 
 {% block page_title %}Your response to ‘{{ brief.title }}’ - Digital Marketplace{% endblock %}
 

--- a/app/templates/briefs/check_your_answers.html
+++ b/app/templates/briefs/check_your_answers.html
@@ -1,4 +1,4 @@
-{% extends "toolkit/layouts/_base_page.html" %}
+{% extends "_base_page.html" %}
 
 {% block page_title %}Your response to ‘{{ brief.title }}’ - Digital Marketplace{% endblock %}
 

--- a/app/templates/briefs/clarification_question.html
+++ b/app/templates/briefs/clarification_question.html
@@ -1,4 +1,4 @@
-{% extends "toolkit/layouts/_base_page.html" %}
+{% extends "_base_page.html" %}
 
 {% block page_title %}Ask a question about {{ brief.title }} – Digital Marketplace{% endblock %}
 

--- a/app/templates/briefs/not_is_supplier_eligible_for_brief_error.html
+++ b/app/templates/briefs/not_is_supplier_eligible_for_brief_error.html
@@ -1,4 +1,4 @@
-{% extends "toolkit/layouts/_base_page.html" %}
+{% extends "_base_page.html" %}
 
 {% block page_title %}Not eligible for opportunity – Digital Marketplace{% endblock %}
 

--- a/app/templates/briefs/question_and_answer_session.html
+++ b/app/templates/briefs/question_and_answer_session.html
@@ -1,4 +1,4 @@
-{% extends "toolkit/layouts/_base_page.html" %}
+{% extends "_base_page.html" %}
 
 {% block page_title %}{{ brief.title }} question and answer session details – Digital Marketplace{% endblock %}
 

--- a/app/templates/briefs/start_brief_response.html
+++ b/app/templates/briefs/start_brief_response.html
@@ -1,4 +1,4 @@
-{% extends "toolkit/layouts/_base_page.html" %}
+{% extends "_base_page.html" %}
 
 {% block page_title %}Apply for {{ brief.title }} – Digital Marketplace{% endblock %}
 

--- a/app/templates/frameworks/opportunities_dashboard.html
+++ b/app/templates/frameworks/opportunities_dashboard.html
@@ -1,4 +1,4 @@
-{% extends "toolkit/layouts/_base_page.html" %}
+{% extends "_base_page.html" %}
 {% import "toolkit/summary-table.html" as summary %}
 {% block page_title %}Opportunities Overview - Digital Marketplace{% endblock %}
 


### PR DESCRIPTION
https://trello.com/c/PpFz5qRc/43-create-a-base-page-for-the-apps

The work to move to govuk-frontend will be easier if we have a base page in each app in which to import macros.

GOVUK Frontend may solve this down the road
https://github.com/alphagov/govuk-frontend/issues/1278

It seems from research (Googling and GOV Pay) for now this is the accepted pattern