### PR TITLE
24-2-update-page-headings-to-govuk-frontend-style-in-brief-responses-frontend

### DIFF
--- a/app/assets/scss/application.scss
+++ b/app/assets/scss/application.scss
@@ -28,7 +28,6 @@ $path: "/suppliers/opportunities/static/images/";
 @import "toolkit/_grids.scss";
 @import "toolkit/_instruction-list.scss";
 @import "toolkit/_notification-banners.scss";
-@import "toolkit/_page-headings.scss";
 @import "toolkit/_phase-banner.scss";
 @import "toolkit/_proposition-header.scss";
 @import "toolkit/_report-a-problem.scss";
@@ -60,6 +59,9 @@ $govuk-compatibility-govukelements: true;
 // App specific styles
 @import "_brief-response.scss";
 @import "_footer.scss";
+
+// Overrides
+@import "overrides/_page_headings";
 
 // Misc styles
 // TODO: Move misc styling into their own partial files or the Digital Marketplace FE Toolkit

--- a/app/assets/scss/overrides/_page_headings.scss
+++ b/app/assets/scss/overrides/_page_headings.scss
@@ -1,0 +1,11 @@
+// FIXME: Temporary, remove once we are using govuk-frontend grids
+//
+// This is needed to push down the page content but more specifically page
+// headings.
+//
+// Previously CSS would adjust top and bottom margins/padding. We should try
+// spacing by pushing content down and not worrying about what is above it.
+
+#content {
+  @include govuk-responsive-margin(7, "top");
+}

--- a/app/templates/briefs/_base_edit_question_page.html
+++ b/app/templates/briefs/_base_edit_question_page.html
@@ -13,13 +13,7 @@
   <div class="grid-row">
     <div class="column-two-thirds">
 
-      {% with
-        heading = question.question,
-        smaller = true
-      %}
-        {% include 'toolkit/page-heading.html' %}
-      {% endwith %}
-
+      <h1 class="govuk-heading-l">{{ question.question }}</h1>
     </div>
   </div>
 

--- a/app/templates/briefs/application_submitted.html
+++ b/app/templates/briefs/application_submitted.html
@@ -29,12 +29,7 @@
   <div class="column-two-thirds">
 
       <div class="dmspeak">
-      {% with
-        heading = "What happens next",
-        smaller = true
-        %}
-          {% include 'toolkit/page-heading.html' %}
-      {% endwith %}
+        <h1 class="govuk-heading-l">What happens next<h1>
 
         <h2 class="heading-xmedium">Shortlist</h2>
 

--- a/app/templates/briefs/check_your_answers.html
+++ b/app/templates/briefs/check_your_answers.html
@@ -32,7 +32,11 @@
 <div class="grid-row">
   <div class="column-two-thirds">
     <h1 class="govuk-heading-l">
-      {{ "Check and submit your answers" if brief_response.status == 'draft' else "Your application for ‘{}’".format(brief.title) }}
+      {% if brief_response.status == 'draft' %}
+        Check and submit your answers
+      {% else %}
+        Your application for ‘{{ brief.title }}’
+      {% endif %}
     </h1>
 
     <div class="dmspeak">

--- a/app/templates/briefs/check_your_answers.html
+++ b/app/templates/briefs/check_your_answers.html
@@ -31,12 +31,9 @@
 {% block main_content %}
 <div class="grid-row">
   <div class="column-two-thirds">
-    {% with
-      heading = "Check and submit your answers" if brief_response.status == 'draft' else "Your application for ‘{}’".format(brief.title),
-      smaller = true
-      %}
-        {% include 'toolkit/page-heading.html' %}
-    {% endwith %}
+    <h1 class="govuk-heading-l">
+      {{ "Check and submit your answers" if brief_response.status == 'draft' else "Your application for ‘{}’".format(brief.title) }}
+    </h1>
 
     <div class="dmspeak">
       {% if brief_response.status != 'draft' %}

--- a/app/templates/briefs/clarification_question.html
+++ b/app/templates/briefs/clarification_question.html
@@ -27,13 +27,7 @@
 <div class="single-question-page">
   <div class="grid-row">
     <div class="column-two-thirds">
-
-      {% with
-        heading = form.clarification_question.question,
-        smaller = true
-      %}
-        {% include 'toolkit/page-heading.html' %}
-      {% endwith %}
+      <h1 class="govuk-heading-l">{{ form.clarification_question.question }}</h1>
 
       <form method="post">
         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />

--- a/app/templates/briefs/question_and_answer_session.html
+++ b/app/templates/briefs/question_and_answer_session.html
@@ -23,12 +23,7 @@
 
 <div class="grid-row">
   <div class="column-two-thirds">
-    {% with
-      heading = "‘{}’ question and answer session details".format(brief.title),
-      smaller = true
-    %}
-      {% include 'toolkit/page-heading.html' %}
-    {% endwith %}
+    <h1 class="govuk-heading-l">{{ "‘{}’ question and answer session details".format(brief.title) }}</h1>
 
     <div class="padding-bottom-small">
       <p>

--- a/app/templates/briefs/question_and_answer_session.html
+++ b/app/templates/briefs/question_and_answer_session.html
@@ -23,7 +23,7 @@
 
 <div class="grid-row">
   <div class="column-two-thirds">
-    <h1 class="govuk-heading-l">{{ "‘{}’ question and answer session details".format(brief.title) }}</h1>
+    <h1 class="govuk-heading-l">‘{{ brief.title }}’ question and answer session details</h1>
 
     <div class="padding-bottom-small">
       <p>

--- a/app/templates/briefs/start_brief_response.html
+++ b/app/templates/briefs/start_brief_response.html
@@ -35,14 +35,7 @@
 
   <div class="grid-row">
     <div class="column-two-thirds dmspeak">
-
-      {%
-        with
-        smaller = true,
-        heading = "Before you start"
-      %}
-        {% include "toolkit/page-heading.html" %}
-      {% endwith %}
+    <h1 class="govuk-heading-l">Before you start</h1>
       
       <div class="explanation-list">
         <p class="lead">To apply for this opportunity, you’ll need to:</p>

--- a/app/templates/frameworks/opportunities_dashboard.html
+++ b/app/templates/frameworks/opportunities_dashboard.html
@@ -24,7 +24,7 @@
     <div class="grid-row">
 
         <div class="column-two-thirds">
-          <h1 class="govuk-heading-l">{{ 'Your {} opportunities'.format(framework.name) }}</h1>
+          <h1 class="govuk-heading-l">Your {{ framework.name }} opportunities</h1>
         </div>
     </div>
 

--- a/app/templates/frameworks/opportunities_dashboard.html
+++ b/app/templates/frameworks/opportunities_dashboard.html
@@ -24,12 +24,7 @@
     <div class="grid-row">
 
         <div class="column-two-thirds">
-            {% with
-                heading = 'Your {} opportunities'.format(framework.name),
-                smaller = True
-            %}
-            {% include 'toolkit/page-heading.html' %}
-            {% endwith %}
+          <h1 class="govuk-heading-l">{{ 'Your {} opportunities'.format(framework.name) }}</h1>
         </div>
     </div>
 

--- a/tests/app/main/test_briefs.py
+++ b/tests/app/main/test_briefs.py
@@ -193,7 +193,7 @@ class TestBriefClarificationQuestions(BaseApplicationTest):
         doc = html.fromstring(html_string)
 
         assert '<script>alert(1)</script>' not in html_string
-        assert '<script>alert(1)</script>' in doc.xpath('//header/h1/text()')[0].strip()
+        assert '<script>alert(1)</script>' in doc.xpath('//h1/text()')[0].strip()
 
     def test_clarification_question_form_requires_existing_brief_id(self):
         self.login()


### PR DESCRIPTION
Update all headings to use HTML tags with GOV.UK Frontend heading styles instead of the digitalmarkteplace-frontend-toolkit page-heading template

### Before


![screencapture-localhost-suppliers-opportunities-10515-question-and-answer-session-2019-10-17-15_03_35](https://user-images.githubusercontent.com/3469840/67015973-5119b500-f0ef-11e9-8ded-2bec2cbe678c.png)



### After

![screencapture-localhost-suppliers-opportunities-10515-question-and-answer-session-2019-10-17-15_02_45](https://user-images.githubusercontent.com/3469840/67015931-3fd0a880-f0ef-11e9-84ca-a99da6e4c4ba.png)

