### PR TITLE
22-2-update-breadcrumbs-to-use-govuk-frontend-component-in-brief-responses-frontend

### DIFF
--- a/app/assets/scss/application.scss
+++ b/app/assets/scss/application.scss
@@ -21,7 +21,6 @@ $path: "/suppliers/opportunities/static/images/";
 @import "shared_scss/_dmspeak.scss";
 
 // Digital Marketplace Front-end toolkit styles (only import the files you need)
-@import "toolkit/_breadcrumb.scss";
 @import "toolkit/_browse-list.scss";
 @import "toolkit/_digital-marketplace-colours.scss";
 @import "toolkit/_grids.scss";

--- a/app/templates/_base_page.html
+++ b/app/templates/_base_page.html
@@ -1,9 +1,7 @@
 {% extends "toolkit/layouts/_base_page.html" %}
 
-{% from "components/breadcrumbs/macro.njk" import govukBreadcrumbs %}
-
-
 // Insert line for each component module import
+{% from "components/breadcrumbs/macro.njk" import govukBreadcrumbs %}
 {% from "components/button/macro.njk" import govukButton %}
 
 {# override content block to add a beforeContent block like the one in govuk-frontend template #}

--- a/app/templates/_base_page.html
+++ b/app/templates/_base_page.html
@@ -1,4 +1,22 @@
 {% extends "toolkit/layouts/_base_page.html" %}
 
+{% from "components/breadcrumbs/macro.njk" import govukBreadcrumbs %}
+
+
 // Insert line for each component module import
 {% from "components/button/macro.njk" import govukButton %}
+
+{# override content block to add a beforeContent block like the one in govuk-frontend template #}
+{% block content %}
+  {% block top_header %}{% endblock %}
+  <div id="wrapper">
+    {% block beforeContent %}
+      {% block breadcrumb %}{% endblock %}
+    {% endblock %}
+    <main id="content" role="main">
+      {% include "toolkit/flash_messages.html" %}
+      {% block main_content %}
+      {% endblock %}
+    </main>
+  </div>
+{% endblock %}

--- a/app/templates/briefs/application_submitted.html
+++ b/app/templates/briefs/application_submitted.html
@@ -4,8 +4,9 @@
 
 {% block breadcrumb %}
 
- {{ govukBreadcrumbs({
-   "items": [
+  {# user supplied strings in the govukBreadcrumbs parameters need to be escaped by a jinja filter #}
+  {{ govukBreadcrumbs({
+    "items": [
       {
         "href": "/",
         "text": "Digital Marketplace"

--- a/app/templates/briefs/application_submitted.html
+++ b/app/templates/briefs/application_submitted.html
@@ -4,24 +4,26 @@
 
 {% block breadcrumb %}
 
-  {%
-    with items = [
+ {{ govukBreadcrumbs({
+   "items": [
       {
-        "link": "/",
-        "label": "Digital Marketplace"
+        "href": "/",
+        "text": "Digital Marketplace"
       },
       {
-        "link": url_for("external.supplier_dashboard"),
-        "label": "Your account"
+        "href": url_for("external.supplier_dashboard"),
+        "text": "Your account"
       },
       {
-        "link": url_for(".opportunities_dashboard", framework_slug=brief.frameworkSlug),
-        "label": "Your {} opportunities".format(brief.frameworkName)
+        "href": url_for(".opportunities_dashboard", framework_slug=brief.frameworkSlug),
+        "text": "Your {} opportunities".format(brief.frameworkName)
+      },
+      {
+        "text": "Responses to ‘{}’ submitted".format(brief.title|e)
       },
     ]
-  %}
-    {% include "toolkit/breadcrumb.html" %}
-  {% endwith %}
+  }) }}
+
 {% endblock %}
 
 {% block main_content %}

--- a/app/templates/briefs/check_your_answers.html
+++ b/app/templates/briefs/check_your_answers.html
@@ -4,6 +4,7 @@
 
 {% block breadcrumb %}
 
+{# user supplied strings in the govukBreadcrumbs parameters need to be escaped by a jinja filter #}
   {{ govukBreadcrumbs({
     "items": [
       {

--- a/app/templates/briefs/check_your_answers.html
+++ b/app/templates/briefs/check_your_answers.html
@@ -4,28 +4,30 @@
 
 {% block breadcrumb %}
 
-  {%
-    with items = [
+  {{ govukBreadcrumbs({
+    "items": [
       {
-        "link": "/",
-        "label": "Digital Marketplace"
+        "href": "/",
+        "text": "Digital Marketplace"
       },
       {
-        "link": url_for("external.supplier_dashboard"),
-        "label": "Your account"
+        "href": url_for("external.supplier_dashboard"),
+        "text": "Your account"
       },
       {
-        "link": url_for(".opportunities_dashboard", framework_slug=brief.frameworkSlug),
-        "label": "Your {} opportunities".format(brief.frameworkName)
+        "href": url_for(".opportunities_dashboard", framework_slug=brief.frameworkSlug),
+        "text": "Your {} opportunities".format(brief.frameworkName)
       },
       {
-        "link": url_for("external.get_brief_by_id", framework_family=brief.framework.family, brief_id=brief.id),
-        "label": "{}".format(brief.title)
+        "href": url_for("external.get_brief_by_id", framework_family=brief.framework.family, brief_id=brief.id),
+        "text": "{}".format(brief.title|e)
+      },
+      {
+        "text": "Check your answers"
       },
     ]
-  %}
-    {% include "toolkit/breadcrumb.html" %}
-  {% endwith %}
+  }) }}
+
 {% endblock %}
 
 {% block main_content %}

--- a/app/templates/briefs/clarification_question.html
+++ b/app/templates/briefs/clarification_question.html
@@ -1,22 +1,25 @@
 {% extends "_base_page.html" %}
 
-{% block page_title %}Ask a question about {{ brief.title }} – Digital Marketplace{% endblock %}
+{% block page_title %}Ask a question about ‘{{ brief.title }}’ – Digital Marketplace{% endblock %}
 
 {% block breadcrumb %}
-  {%
-    with items = [
+
+  {{ govukBreadcrumbs({
+    "items": [
       {
-        "link": "/",
-        "label": "Digital Marketplace",
+        "href": "/",
+        "text": "Digital Marketplace",
       },
       {
-        "link": url_for("external.supplier_dashboard"),
-        "label": "Your account",
+        "href": url_for("external.supplier_dashboard"),
+        "text": "Your account",
+      },
+      {
+        "text": "Ask a question about ‘{}’".format(brief.title|e)
       },
     ]
-  %}
-    {% include "toolkit/breadcrumb.html" %}
-  {% endwith %}
+  }) }}
+
 {% endblock %}
 
 {% block main_content %}

--- a/app/templates/briefs/clarification_question.html
+++ b/app/templates/briefs/clarification_question.html
@@ -4,6 +4,7 @@
 
 {% block breadcrumb %}
 
+  {# user supplied strings in the govukBreadcrumbs parameters need to be escaped by a jinja filter #}
   {{ govukBreadcrumbs({
     "items": [
       {

--- a/app/templates/briefs/edit_brief_response_question.html
+++ b/app/templates/briefs/edit_brief_response_question.html
@@ -2,6 +2,7 @@
 
 {% block breadcrumb %}
 
+  {# user supplied strings in the govukBreadcrumbs parameters need to be escaped by a jinja filter #}
   {{ govukBreadcrumbs({
     "items": [
       {

--- a/app/templates/briefs/edit_brief_response_question.html
+++ b/app/templates/briefs/edit_brief_response_question.html
@@ -2,24 +2,26 @@
 
 {% block breadcrumb %}
 
-  {%
-    with items = [
+  {{ govukBreadcrumbs({
+    "items": [
       {
-        "link": "/",
-        "label": "Digital Marketplace"
+        "href": "/",
+        "text": "Digital Marketplace"
       },
       {
-        "link": url_for('external.list_opportunities', framework_family=brief.framework.family),
-        "label": "Supplier opportunities"
+        "href": url_for('external.list_opportunities', framework_family=brief.framework.family),
+        "text": "Supplier opportunities"
       },
       {
-        "link": url_for('external.get_brief_by_id', framework_family=brief.framework.family, brief_id=brief.id),
-        "label": brief.title
+        "href": url_for('external.get_brief_by_id', framework_family=brief.framework.family, brief_id=brief.id),
+        "text": brief.title
+      },
+      {
+        "text": question.question|e
       },
     ]
-  %}
-    {% include "toolkit/breadcrumb.html" %}
-  {% endwith %}
+  }) }}
+
 {% endblock %}
 
 {% block save_button %}

--- a/app/templates/briefs/question_and_answer_session.html
+++ b/app/templates/briefs/question_and_answer_session.html
@@ -4,6 +4,7 @@
 
 {% block breadcrumb %}
 
+  {# user supplied strings in the govukBreadcrumbs parameters need to be escaped by a jinja filter #}
   {{ govukBreadcrumbs({
     "items": [
       {

--- a/app/templates/briefs/question_and_answer_session.html
+++ b/app/templates/briefs/question_and_answer_session.html
@@ -1,22 +1,25 @@
 {% extends "_base_page.html" %}
 
-{% block page_title %}{{ brief.title }} question and answer session details – Digital Marketplace{% endblock %}
+{% block page_title %}‘{{ brief.title }}’ question and answer session details – Digital Marketplace{% endblock %}
 
 {% block breadcrumb %}
-  {%
-    with items = [
+
+  {{ govukBreadcrumbs({
+    "items": [
       {
-        "link": "/",
-        "label": "Digital Marketplace",
+        "href": "/",
+        "text": "Digital Marketplace",
       },
       {
-        "link": url_for("external.supplier_dashboard"),
-        "label": "Your account",
+        "href": url_for("external.supplier_dashboard"),
+        "text": "Your account",
+      },
+      {
+        "text": "‘{}’ question and answer session details".format(brief.title|e)
       },
     ]
-  %}
-    {% include "toolkit/breadcrumb.html" %}
-  {% endwith %}
+  }) }}
+
 {% endblock %}
 
 {% block main_content %}

--- a/app/templates/briefs/start_brief_response.html
+++ b/app/templates/briefs/start_brief_response.html
@@ -1,26 +1,29 @@
 {% extends "_base_page.html" %}
 
-{% block page_title %}Apply for {{ brief.title }} – Digital Marketplace{% endblock %}
+{% block page_title %}Apply for ‘{{ brief.title }}’ – Digital Marketplace{% endblock %}
 
 {% block breadcrumb %}
-  {%
-    with items = [
+
+  {{ govukBreadcrumbs({
+    "items": [
       {
-        "link": "/",
-        "label": "Digital Marketplace"
+        "href": "/",
+        "text": "Digital Marketplace"
       },
       {
-        "link": url_for('external.list_opportunities', framework_family=brief.framework.family),
-        "label": "Supplier opportunities"
+        "href": url_for('external.list_opportunities', framework_family=brief.framework.family),
+        "text": "Supplier opportunities"
       },
       {
-        "link": url_for('external.get_brief_by_id', framework_family=brief.framework.family, brief_id=brief.id),
-        "label": brief.title
+        "href": url_for('external.get_brief_by_id', framework_family=brief.framework.family, brief_id=brief.id),
+        "text": brief.title|e
+      },
+      {
+        "text": "Apply for ‘{}’".format(brief.title|e)
       },
     ]
-  %}
-    {% include "toolkit/breadcrumb.html" %}
-  {% endwith %}
+  }) }}
+
 {% endblock %}
 
 {% block main_content %}

--- a/app/templates/briefs/start_brief_response.html
+++ b/app/templates/briefs/start_brief_response.html
@@ -4,6 +4,7 @@
 
 {% block breadcrumb %}
 
+  {# user supplied strings in the govukBreadcrumbs parameters need to be escaped by a jinja filter #}
   {{ govukBreadcrumbs({
     "items": [
       {

--- a/app/templates/frameworks/opportunities_dashboard.html
+++ b/app/templates/frameworks/opportunities_dashboard.html
@@ -3,20 +3,23 @@
 {% block page_title %}Opportunities Overview - Digital Marketplace{% endblock %}
 
 {% block breadcrumb %}
-  {%
-    with items = [
-    {
-        "link": "/",
-        "label": "Digital Marketplace"
-    },
-    {
-        "link": url_for("external.supplier_dashboard"),
-        "label": "Your account"
-    }
+
+  {{ govukBreadcrumbs({
+    "items": [
+      {
+        "href": "/",
+        "text": "Digital Marketplace"
+      },
+      {
+        "href": url_for("external.supplier_dashboard"),
+        "text": "Your account"
+      },
+      {
+        "text": "Opportunities Overview"
+      },
     ]
-  %}
-    {% include "toolkit/breadcrumb.html" %}
-  {% endwith %}
+  }) }}
+
 {% endblock %}
 
 {% block main_content %}

--- a/tests/app/helpers.py
+++ b/tests/app/helpers.py
@@ -264,14 +264,18 @@ class BaseApplicationTest(object):
             ('Digital Marketplace', '/'),
             ('Supplier opportunities', '/digital-outcomes-and-specialists/opportunities'),
             ('Brief title', '/digital-outcomes-and-specialists/opportunities/127'),
+            ('Question title', 'without href')
         ]
         """
         breadcrumbs = html.fromstring(response.get_data(as_text=True)).xpath(
-            '//*[@id="global-breadcrumb"]/nav/ol/li'
+            '//*[@class="govuk-breadcrumbs"]/ol/li'
         )
 
         assert len(breadcrumbs) == len(expected_breadcrumbs)
 
         for index, link in enumerate(expected_breadcrumbs):
-            assert breadcrumbs[index].find('a').text_content().strip() == link[0]
-            assert breadcrumbs[index].find('a').get('href').strip() == link[1]
+            if index + 1 < len(expected_breadcrumbs):  # last item must not have a href
+                assert breadcrumbs[index].find('a').text_content().strip() == link[0]
+                assert breadcrumbs[index].find('a').get('href').strip() == link[1]
+            else:
+                assert breadcrumbs[index].text_content().strip() == link[0]

--- a/tests/app/main/test_briefs.py
+++ b/tests/app/main/test_briefs.py
@@ -2037,7 +2037,8 @@ class TestResponseResultPage(BaseApplicationTest, BriefResponseTestHelpers):
                 'Your Digital Outcomes and Specialists opportunities',
                 '/suppliers/opportunities/frameworks/digital-outcomes-and-specialists'
             ),
-            ('Your response to ‘I need a thing to do a thing’', ),
+            # ('Your response to ‘I need a thing to do a thing’', ),
+            ('Responses to ‘I need a thing to do a thing’ submitted', ),
         ]
         self.assert_breadcrumbs(res, expected_breadcrumbs)
 

--- a/tests/app/main/test_briefs.py
+++ b/tests/app/main/test_briefs.py
@@ -1791,7 +1791,8 @@ class TestStartBriefResponseApplication(BaseApplicationTest, BriefResponseTestHe
         expected_breadcrumbs = [
             ('Digital Marketplace', '/'),
             ('Supplier opportunities', '/digital-outcomes-and-specialists/opportunities'),
-            (brief['title'], '/digital-outcomes-and-specialists/opportunities/{}'.format(brief['id']))
+            (brief['title'], '/digital-outcomes-and-specialists/opportunities/{}'.format(brief['id'])),
+            ("Apply for ‘{}’".format(brief['title']), '')
         ]
         self.assert_breadcrumbs(res, expected_breadcrumbs)
 
@@ -2036,6 +2037,7 @@ class TestResponseResultPage(BaseApplicationTest, BriefResponseTestHelpers):
                 'Your Digital Outcomes and Specialists opportunities',
                 '/suppliers/opportunities/frameworks/digital-outcomes-and-specialists'
             ),
+            ('Your response to ‘I need a thing to do a thing’', ),
         ]
         self.assert_breadcrumbs(res, expected_breadcrumbs)
 


### PR DESCRIPTION
Use GOV.UK frontend breadcrumbs element

https://trello.com/c/WfVAHKfa/22-2-update-breadcrumbs-to-use-govuk-frontend-component-in-brief-responses-frontend

* Add element macro import to _base_page.html
* Remove GOV.UK toolkit breadcrumb from application.scss
* Override content block to add a beforeContent block in _base_page.html
* Change breadcrumbs to use macro



### Before 

<img width="1427" alt="Screen Shot 2019-10-17 at 16 10 37" src="https://user-images.githubusercontent.com/3469840/67022204-c76ee500-f0f8-11e9-9273-147f52b47f1c.png">



### After

<img width="1440" alt="Screen Shot 2019-10-17 at 16 09 33" src="https://user-images.githubusercontent.com/3469840/67022230-ce95f300-f0f8-11e9-94c8-f2ba5ddf3d19.png">


