### PR TITLE
Bump contentloader and PyYaml

### DIFF
--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -9,6 +9,6 @@ itsdangerous==0.24 # pyup: ignore
 gds-metrics==0.2.0
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@48.5.0#egg=digitalmarketplace-utils==48.5.0
-git+https://github.com/alphagov/digitalmarketplace-content-loader.git@6.0.0#egg=digitalmarketplace-content-loader==6.0.0
+git+https://github.com/alphagov/digitalmarketplace-content-loader.git@7.0.0#egg=digitalmarketplace-content-loader==7.0.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@21.4.0#egg=digitalmarketplace-apiclient==21.4.0
 git+https://github.com/alphagov/govuk-frontend-jinja.git@v0.4.0-alpha#egg=govuk-frontend-jinja==0.4.0-alpha

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,17 +10,17 @@ itsdangerous==0.24 # pyup: ignore
 gds-metrics==0.2.0
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@48.5.0#egg=digitalmarketplace-utils==48.5.0
-git+https://github.com/alphagov/digitalmarketplace-content-loader.git@6.0.0#egg=digitalmarketplace-content-loader==6.0.0
+git+https://github.com/alphagov/digitalmarketplace-content-loader.git@7.0.0#egg=digitalmarketplace-content-loader==7.0.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@21.4.0#egg=digitalmarketplace-apiclient==21.4.0
 git+https://github.com/alphagov/govuk-frontend-jinja.git@v0.4.0-alpha#egg=govuk-frontend-jinja==0.4.0-alpha
 
 ## The following requirements were added by pip freeze:
-asn1crypto==1.1.0
+asn1crypto==1.2.0
 blinker==1.4
-boto3==1.9.250
-botocore==1.12.250
+boto3==1.9.253
+botocore==1.12.253
 certifi==2019.9.11
-cffi==1.13.0
+cffi==1.13.1
 chardet==3.0.4
 Click==7.0
 contextlib2==0.6.0.post1
@@ -30,7 +30,7 @@ docopt==0.6.2
 docutils==0.15.2
 Flask-Script==2.0.6
 fleep==1.0.1
-future==0.18.0
+future==0.18.1
 govuk-country-register==0.5.0
 idna==2.8
 inflection==0.3.1
@@ -48,7 +48,7 @@ PyJWT==1.7.1
 python-dateutil==2.8.0
 python-json-logger==0.1.11
 pytz==2019.3
-PyYAML==3.13
+PyYAML==5.1.2
 requests==2.22.0
 s3transfer==0.2.1
 six==1.12.0


### PR DESCRIPTION
https://trello.com/c/51brdJKx/1201-upgrade-pyyaml-to-5x

Bumps the content-loader (and its PyYAML dependency) to bring in the security fix. Functional tests pass locally 👍 