### PR TITLE
Add JavaScript init for GOV.UK Frontend JavaScripts

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -20,6 +20,7 @@
 //= require _analytics.js
 //= require _selection-buttons.js
 
+GOVUKFrontend.initAll()
 
 (function(GOVUK, GDM) {
 


### PR DESCRIPTION
This was missed when adding digitalmarketplace-govuk-frontend, we should add it now.