### PR TITLE
Use Digital Marketplace GOV.UK Template error pages

### DIFF
--- a/app/templates/_base_page.html
+++ b/app/templates/_base_page.html
@@ -4,6 +4,9 @@
 {% from "components/breadcrumbs/macro.njk" import govukBreadcrumbs %}
 {% from "components/button/macro.njk" import govukButton %}
 
+{# TODO: Remove once we start removing govuk_template, GOV.UK Frontend template uses pageTitle #}
+{% block page_title %}{% block pageTitle %}{% endblock %}{% endblock %}
+
 {# override content block to add a beforeContent block like the one in govuk-frontend template #}
 {% block content %}
   {% block top_header %}{% endblock %}

--- a/app/templates/_base_page.html
+++ b/app/templates/_base_page.html
@@ -16,7 +16,10 @@
     {% endblock %}
     <main id="content" role="main">
       {% include "toolkit/flash_messages.html" %}
+      {# TODO: Remove this block when we start removing govuk_template but be sure #}
+      {#       To keep the inner block mainContent otherwise no content will be rendered #}
       {% block main_content %}
+        {% block mainContent %}{% endblock %}
       {% endblock %}
     </main>
   </div>

--- a/app/templates/briefs/_base_edit_question_page.html
+++ b/app/templates/briefs/_base_edit_question_page.html
@@ -5,7 +5,8 @@
   {{ question.question }} – Digital Marketplace
 {% endblock %}
 
-{% block main_content %}
+{% block mainContent %}
+
   {% include 'toolkit/forms/validation.html' %}
 
   {% if question.type != 'multiquestion' %}

--- a/app/templates/briefs/_base_edit_question_page.html
+++ b/app/templates/briefs/_base_edit_question_page.html
@@ -1,7 +1,9 @@
 {% extends "_base_page.html" %}
 {% import "toolkit/forms/macros/forms.html" as forms %}
 
-{% block page_title %}{{ question.question }} – Digital Marketplace{% endblock %}
+{% block pageTitle %}
+  {{ question.question }} – Digital Marketplace
+{% endblock %}
 
 {% block main_content %}
   {% include 'toolkit/forms/validation.html' %}

--- a/app/templates/briefs/application_submitted.html
+++ b/app/templates/briefs/application_submitted.html
@@ -29,7 +29,8 @@
 
 {% endblock %}
 
-{% block main_content %}
+{% block mainContent %}
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
 

--- a/app/templates/briefs/application_submitted.html
+++ b/app/templates/briefs/application_submitted.html
@@ -1,6 +1,8 @@
 {% extends "_base_page.html" %}
 
-{% block page_title %}Your response to ‘{{ brief.title }}’ - Digital Marketplace{% endblock %}
+{% block pageTitle %}
+  Your response to ‘{{ brief.title }}’ - Digital Marketplace
+{% endblock %}
 
 {% block breadcrumb %}
 

--- a/app/templates/briefs/check_your_answers.html
+++ b/app/templates/briefs/check_your_answers.html
@@ -1,6 +1,8 @@
 {% extends "_base_page.html" %}
 
-{% block page_title %}Your response to ‘{{ brief.title }}’ - Digital Marketplace{% endblock %}
+{% block pageTitle %}
+  Your response to ‘{{ brief.title }}’ - Digital Marketplace
+{% endblock %}
 
 {% block breadcrumb %}
 

--- a/app/templates/briefs/check_your_answers.html
+++ b/app/templates/briefs/check_your_answers.html
@@ -33,7 +33,8 @@
 
 {% endblock %}
 
-{% block main_content %}
+{% block mainContent %}
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l">

--- a/app/templates/briefs/clarification_question.html
+++ b/app/templates/briefs/clarification_question.html
@@ -25,7 +25,8 @@
 
 {% endblock %}
 
-{% block main_content %}
+{% block mainContent %}
+
 {% with lede = "There was a problem with your submitted question" %}
   {% include "toolkit/forms/validation.html" %}
 {% endwith %}

--- a/app/templates/briefs/clarification_question.html
+++ b/app/templates/briefs/clarification_question.html
@@ -1,6 +1,8 @@
 {% extends "_base_page.html" %}
 
-{% block page_title %}Ask a question about ‘{{ brief.title }}’ – Digital Marketplace{% endblock %}
+{% block pageTitle %}
+  Ask a question about ‘{{ brief.title }}’ – Digital Marketplace
+{% endblock %}
 
 {% block breadcrumb %}
 

--- a/app/templates/briefs/not_is_supplier_eligible_for_brief_error.html
+++ b/app/templates/briefs/not_is_supplier_eligible_for_brief_error.html
@@ -4,7 +4,7 @@
   Not eligible for opportunity – Digital Marketplace
 {% endblock %}
 
-{% block main_content %}
+{% block mainContent %}
 
 {% with inhibited_action="ask a question about" if clarification_question else "apply for" %}
 <div class="govuk-grid-row" data-reason="{{ data_reason_slug }}">

--- a/app/templates/briefs/not_is_supplier_eligible_for_brief_error.html
+++ b/app/templates/briefs/not_is_supplier_eligible_for_brief_error.html
@@ -1,6 +1,8 @@
 {% extends "_base_page.html" %}
 
-{% block page_title %}Not eligible for opportunity – Digital Marketplace{% endblock %}
+{% block pageTitle %}
+  Not eligible for opportunity – Digital Marketplace
+{% endblock %}
 
 {% block main_content %}
 

--- a/app/templates/briefs/question_and_answer_session.html
+++ b/app/templates/briefs/question_and_answer_session.html
@@ -25,7 +25,7 @@
 
 {% endblock %}
 
-{% block main_content %}
+{% block mainContent %}
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/templates/briefs/question_and_answer_session.html
+++ b/app/templates/briefs/question_and_answer_session.html
@@ -1,6 +1,8 @@
 {% extends "_base_page.html" %}
 
-{% block page_title %}‘{{ brief.title }}’ question and answer session details – Digital Marketplace{% endblock %}
+{% block pageTitle %}
+  ‘{{ brief.title }}’ question and answer session details – Digital Marketplace
+{% endblock %}
 
 {% block breadcrumb %}
 

--- a/app/templates/briefs/start_brief_response.html
+++ b/app/templates/briefs/start_brief_response.html
@@ -29,7 +29,7 @@
 
 {% endblock %}
 
-{% block main_content %}
+{% block mainContent %}
 
   {%
     set lot_content = {

--- a/app/templates/briefs/start_brief_response.html
+++ b/app/templates/briefs/start_brief_response.html
@@ -1,6 +1,8 @@
 {% extends "_base_page.html" %}
 
-{% block page_title %}Apply for ‘{{ brief.title }}’ – Digital Marketplace{% endblock %}
+{% block pageTitle %}
+  Apply for ‘{{ brief.title }}’ – Digital Marketplace
+{% endblock %}
 
 {% block breadcrumb %}
 

--- a/app/templates/frameworks/opportunities_dashboard.html
+++ b/app/templates/frameworks/opportunities_dashboard.html
@@ -1,6 +1,9 @@
 {% extends "_base_page.html" %}
 {% import "toolkit/summary-table.html" as summary %}
-{% block page_title %}Opportunities Overview - Digital Marketplace{% endblock %}
+
+{% block pageTitle %}
+  Opportunities Overview - Digital Marketplace
+{% endblock %}
 
 {% block breadcrumb %}
 

--- a/app/templates/frameworks/opportunities_dashboard.html
+++ b/app/templates/frameworks/opportunities_dashboard.html
@@ -25,7 +25,7 @@
 
 {% endblock %}
 
-{% block main_content %}
+{% block mainContent %}
 
     <div class="govuk-grid-row">
 

--- a/config.py
+++ b/config.py
@@ -53,9 +53,11 @@ class Config(object):
     @staticmethod
     def init_app(app):
         repo_root = os.path.abspath(os.path.dirname(__file__))
+        digitalmarketplace_govuk_frontend = os.path.join(repo_root, "node_modules", "digitalmarketplace-govuk-frontend")
         template_folders = [
-            os.path.join(repo_root, 'app', 'templates'),
-            os.path.join(repo_root, 'node_modules', 'digitalmarketplace-govuk-frontend', 'govuk-frontend'),
+            os.path.join(repo_root, "app", "templates"),
+            os.path.join(digitalmarketplace_govuk_frontend, "digitalmarketplace", "templates"),
+            os.path.join(digitalmarketplace_govuk_frontend, "govuk-frontend"),
         ]
         jinja_loader = jinja2.FileSystemLoader(template_folders)
         app.jinja_loader = jinja_loader

--- a/package-lock.json
+++ b/package-lock.json
@@ -1333,9 +1333,9 @@
       }
     },
     "digitalmarketplace-govuk-frontend": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/digitalmarketplace-govuk-frontend/-/digitalmarketplace-govuk-frontend-0.1.0.tgz",
-      "integrity": "sha512-KmPwk1vZmHnDN1nD/sTkjjkbPVcNriaY7ROeamhFMory38HdsFCjqRc4rCcep881riPz9r4bpH17JX43YWrRBA=="
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/digitalmarketplace-govuk-frontend/-/digitalmarketplace-govuk-frontend-0.2.1.tgz",
+      "integrity": "sha512-rrXK/GEFiHDsXv2IP0d8lOYfW1yDgh5OX/lOl38gn/uAmHlqNdzhpZws6Ioro7IoG593CoSl5aWewuuUHBdgYA=="
     },
     "dir-glob": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "del": "^5.1.0",
     "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#v16.0.10",
     "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v35.0.1",
-    "digitalmarketplace-govuk-frontend": "^0.1.0",
+    "digitalmarketplace-govuk-frontend": "^0.2.1",
     "govuk-elements-sass": "3.0.3",
     "govuk_frontend_toolkit": "5.0.3",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.19.2/jinja_govuk_template-0.19.2.tgz",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "1.0.0",
   "private": true,
   "engines": {
-    "node": "^ 10.15"
+    "node": "^10.16.3"
   },
   "dependencies": {
     "colors": "1.1.2",

--- a/tests/app/test_application.py
+++ b/tests/app/test_application.py
@@ -45,15 +45,20 @@ class TestApplication(BaseApplicationTest):
         assert "Please do not attempt the same request again." in res.get_data(as_text=True)
 
     def test_404(self):
-        res = self.client.get('/service/1234')
+        res = self.client.get("/service/1234")
         assert res.status_code == 404
-        assert u"Check you’ve entered the correct web " \
-            u"address or start again on the Digital Marketplace homepage." in res.get_data(as_text=True)
-        assert u"If you can’t find what you’re looking for, contact us at " \
-            u"<a href=\"mailto:cloud_digital@crowncommercial.gov.uk?" \
-            u"subject=Digital%20Marketplace%20feedback\" title=\"Please " \
-            u"send feedback to cloud_digital@crowncommercial.gov.uk\">" \
-            u"cloud_digital@crowncommercial.gov.uk</a>" in res.get_data(as_text=True)
+        html = res.get_data(as_text=True)
+        assert (
+            "Check you’ve entered the correct web address"
+            " or start again on the Digital Marketplace homepage." in html
+        )
+        assert (
+            "If you can’t find what you’re looking for, contact us at "
+            '<a class="govuk-link" href="mailto:cloud_digital@crowncommercial.gov.uk?'
+            'subject=Digital%20Marketplace%20feedback" title="Please '
+            'send feedback to cloud_digital@crowncommercial.gov.uk">'
+            "cloud_digital@crowncommercial.gov.uk</a>" in html
+        )
 
     def test_503(self):
         self.data_api_client.get_brief.side_effect = HTTPError('API is down')


### PR DESCRIPTION
Ticket: https://trello.com/c/ZxYMd5ET/95-use-error-page-templates-from-digital-marketplace-govuk-frontend

This PR updates digitalmarketplace-govuk-frontend to v0.2.1 and adds its templates to the Jinja environment, which has the effect of changing its error pages to use newer styles.

---

## Screenshots

### Before

![screenshot of 404 page with small heading and body text](https://user-images.githubusercontent.com/503614/68290769-6cd60280-0080-11ea-930d-7da09dac7075.png)

### After

![screenshot of 404 page with large heading and body text](https://user-images.githubusercontent.com/503614/68290787-76f80100-0080-11ea-846d-ce5fa63710b4.png)
