### PR TITLE
Remove manual escaping from Jinja templates

### DIFF
--- a/app/templates/briefs/application_submitted.html
+++ b/app/templates/briefs/application_submitted.html
@@ -6,7 +6,6 @@
 
 {% block breadcrumb %}
 
-  {# user supplied strings in the govukBreadcrumbs parameters need to be escaped by a jinja filter #}
   {{ govukBreadcrumbs({
     "items": [
       {
@@ -22,7 +21,7 @@
         "text": "Your {} opportunities".format(brief.frameworkName)
       },
       {
-        "text": "Responses to ‘{}’ submitted".format(brief.title|e)
+        "text": "Responses to ‘{}’ submitted".format(brief.title)
       },
     ]
   }) }}

--- a/app/templates/briefs/check_your_answers.html
+++ b/app/templates/briefs/check_your_answers.html
@@ -6,7 +6,6 @@
 
 {% block breadcrumb %}
 
-{# user supplied strings in the govukBreadcrumbs parameters need to be escaped by a jinja filter #}
   {{ govukBreadcrumbs({
     "items": [
       {
@@ -23,7 +22,7 @@
       },
       {
         "href": url_for("external.get_brief_by_id", framework_family=brief.framework.family, brief_id=brief.id),
-        "text": "{}".format(brief.title|e)
+        "text": "{}".format(brief.title)
       },
       {
         "text": "Check your answers"

--- a/app/templates/briefs/clarification_question.html
+++ b/app/templates/briefs/clarification_question.html
@@ -6,7 +6,6 @@
 
 {% block breadcrumb %}
 
-  {# user supplied strings in the govukBreadcrumbs parameters need to be escaped by a jinja filter #}
   {{ govukBreadcrumbs({
     "items": [
       {
@@ -18,7 +17,7 @@
         "text": "Your account",
       },
       {
-        "text": "Ask a question about ‘{}’".format(brief.title|e)
+        "text": "Ask a question about ‘{}’".format(brief.title)
       },
     ]
   }) }}

--- a/app/templates/briefs/edit_brief_response_question.html
+++ b/app/templates/briefs/edit_brief_response_question.html
@@ -2,7 +2,6 @@
 
 {% block breadcrumb %}
 
-  {# user supplied strings in the govukBreadcrumbs parameters need to be escaped by a jinja filter #}
   {{ govukBreadcrumbs({
     "items": [
       {
@@ -18,7 +17,7 @@
         "text": brief.title
       },
       {
-        "text": question.question|e
+        "text": question.question
       },
     ]
   }) }}

--- a/app/templates/briefs/question_and_answer_session.html
+++ b/app/templates/briefs/question_and_answer_session.html
@@ -6,7 +6,6 @@
 
 {% block breadcrumb %}
 
-  {# user supplied strings in the govukBreadcrumbs parameters need to be escaped by a jinja filter #}
   {{ govukBreadcrumbs({
     "items": [
       {
@@ -18,7 +17,7 @@
         "text": "Your account",
       },
       {
-        "text": "‘{}’ question and answer session details".format(brief.title|e)
+        "text": "‘{}’ question and answer session details".format(brief.title)
       },
     ]
   }) }}

--- a/app/templates/briefs/start_brief_response.html
+++ b/app/templates/briefs/start_brief_response.html
@@ -6,7 +6,6 @@
 
 {% block breadcrumb %}
 
-  {# user supplied strings in the govukBreadcrumbs parameters need to be escaped by a jinja filter #}
   {{ govukBreadcrumbs({
     "items": [
       {
@@ -19,10 +18,10 @@
       },
       {
         "href": url_for('external.get_brief_by_id', framework_family=brief.framework.family, brief_id=brief.id),
-        "text": brief.title|e
+        "text": brief.title
       },
       {
-        "text": "Apply for ‘{}’".format(brief.title|e)
+        "text": "Apply for ‘{}’".format(brief.title)
       },
     ]
   }) }}

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -11,4 +11,4 @@ gds-metrics==0.2.0
 git+https://github.com/alphagov/digitalmarketplace-utils.git@48.5.0#egg=digitalmarketplace-utils==48.5.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@7.0.0#egg=digitalmarketplace-content-loader==7.0.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@21.4.0#egg=digitalmarketplace-apiclient==21.4.0
-git+https://github.com/alphagov/govuk-frontend-jinja.git@v0.4.0-alpha#egg=govuk-frontend-jinja==0.4.0-alpha
+git+https://github.com/alphagov/govuk-frontend-jinja.git@v0.5.1-alpha#egg=govuk-frontend-jinja==0.5.1-alpha

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,15 +12,15 @@ gds-metrics==0.2.0
 git+https://github.com/alphagov/digitalmarketplace-utils.git@48.5.0#egg=digitalmarketplace-utils==48.5.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@7.0.0#egg=digitalmarketplace-content-loader==7.0.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@21.4.0#egg=digitalmarketplace-apiclient==21.4.0
-git+https://github.com/alphagov/govuk-frontend-jinja.git@v0.4.0-alpha#egg=govuk-frontend-jinja==0.4.0-alpha
+git+https://github.com/alphagov/govuk-frontend-jinja.git@v0.5.1-alpha#egg=govuk-frontend-jinja==0.5.1-alpha
 
 ## The following requirements were added by pip freeze:
 asn1crypto==1.2.0
 blinker==1.4
-boto3==1.9.253
-botocore==1.12.253
+boto3==1.10.14
+botocore==1.13.14
 certifi==2019.9.11
-cffi==1.13.1
+cffi==1.13.2
 chardet==3.0.4
 Click==7.0
 contextlib2==0.6.0.post1
@@ -30,7 +30,7 @@ docopt==0.6.2
 docutils==0.15.2
 Flask-Script==2.0.6
 fleep==1.0.1
-future==0.18.1
+future==0.18.2
 govuk-country-register==0.5.0
 idna==2.8
 inflection==0.3.1
@@ -40,7 +40,7 @@ mailchimp3==3.0.6
 Markdown==2.6.11
 MarkupSafe==1.1.1
 monotonic==1.5
-notifications-python-client==5.3.0
+notifications-python-client==5.4.0
 odfpy==1.4.0
 prometheus-client==0.2.0
 pycparser==2.19
@@ -51,7 +51,7 @@ pytz==2019.3
 PyYAML==5.1.2
 requests==2.22.0
 s3transfer==0.2.1
-six==1.12.0
+six==1.13.0
 unicodecsv==0.14.1
 urllib3==1.25.6
 Werkzeug==0.16.0


### PR DESCRIPTION
Ticket: https://trello.com/c/hubmy1jb/1108-remove-the-escape-filter-from-br-fes-templates-because-autoescaping-is-turned-on

govuk-frontend-jinja > v0.5.0 enables autoescaping on Nunjucks templates by
default, so we don't need to escape inputs to macros.