### PR TITLE
Remove secondary-action-link component

### DIFF
--- a/app/assets/scss/application.scss
+++ b/app/assets/scss/application.scss
@@ -27,7 +27,6 @@ $path: "/suppliers/opportunities/static/images/";
 @import "toolkit/_phase-banner.scss";
 @import "toolkit/_proposition-header.scss";
 @import "toolkit/_report-a-problem.scss";
-@import "toolkit/_secondary-action-link.scss";
 @import "toolkit/_temporary-message.scss";
 @import "toolkit/forms/_hint.scss";
 @import "toolkit/forms/_pricing.scss";

--- a/app/templates/briefs/application_submitted.html
+++ b/app/templates/briefs/application_submitted.html
@@ -81,7 +81,7 @@
   class="govuk-link govuk-link--no-visited-state govuk-!-margin-top-6 govuk-!-display-inline-block"
   href="{{ url_for('.opportunities_dashboard', framework_slug=brief.frameworkSlug) }}"
 >
-  Your {{ brief.frameworkName }} opportunities
+  Return to your opportunities
 </a>
 
 {% endblock %}

--- a/app/templates/briefs/application_submitted.html
+++ b/app/templates/briefs/application_submitted.html
@@ -77,12 +77,11 @@
   </div>
 </div>
 
-  {%
-    with
-      url = url_for(".opportunities_dashboard", framework_slug=brief.frameworkSlug),
-      text = "Your {} opportunities".format(brief.frameworkName)
-  %}
-    {% include "toolkit/secondary-action-link.html" %}
-  {% endwith %}
+<a
+  class="govuk-link govuk-link--no-visited-state govuk-!-margin-top-6 govuk-!-display-inline-block"
+  href="{{ url_for('.opportunities_dashboard', framework_slug=brief.frameworkSlug) }}"
+>
+  Your {{ brief.frameworkName }} opportunities
+</a>
 
 {% endblock %}

--- a/app/templates/briefs/application_submitted.html
+++ b/app/templates/briefs/application_submitted.html
@@ -21,7 +21,7 @@
         "text": "Your {} opportunities".format(brief.frameworkName)
       },
       {
-        "text": "Responses to ‘{}’ submitted".format(brief.title)
+        "text": "Response to ‘{}’ submitted".format(brief.title)
       },
     ]
   }) }}

--- a/app/templates/briefs/check_your_answers.html
+++ b/app/templates/briefs/check_your_answers.html
@@ -75,7 +75,7 @@
         class="govuk-link govuk-link--no-visited-state govuk-!-margin-top-6 govuk-!-display-inline-block"
         href="{{ url_for('.opportunities_dashboard', framework_slug=brief.frameworkSlug) }}"
       >
-        Your {{ brief.frameworkName }} opportunities
+        Return to your opportunities
       </a>
     {% endif %}
   </div>

--- a/app/templates/briefs/check_your_answers.html
+++ b/app/templates/briefs/check_your_answers.html
@@ -71,13 +71,12 @@
         {{ govukButton({"text": "Submit application"}) }}
       </form>
     {% else %}
-      {%
-        with
-        url = url_for(".opportunities_dashboard", framework_slug=brief.frameworkSlug),
-        text = "Your {} opportunities".format(brief.frameworkName)
-      %}
-        {% include "toolkit/secondary-action-link.html" %}
-      {% endwith %}
+      <a
+        class="govuk-link govuk-link--no-visited-state govuk-!-margin-top-6 govuk-!-display-inline-block"
+        href="{{ url_for('.opportunities_dashboard', framework_slug=brief.frameworkSlug) }}"
+      >
+        Your {{ brief.frameworkName }} opportunities
+      </a>
     {% endif %}
   </div>
 </div>

--- a/app/templates/briefs/check_your_answers.html
+++ b/app/templates/briefs/check_your_answers.html
@@ -63,23 +63,23 @@
 </div>
 
 <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-      {% if brief_response.status == 'draft' and brief.status == 'live' %}
-        <form action="{{ url_for('.check_brief_response_answers', brief_id=brief.id, brief_response_id=brief_response.id) }}" method="post">
-          <p class="govuk-body">Once you submit you can update your application until {{ brief.applicationsClosedAt|utcdatetimeformat }}.</p>
-          <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
-          {{ govukButton({"text": "Submit application"}) }}
-        </form>
-      {% else %}
-          {%
-            with
-              url = url_for(".opportunities_dashboard", framework_slug=brief.frameworkSlug),
-              text = "Your {} opportunities".format(brief.frameworkName)
-          %}
-            {% include "toolkit/secondary-action-link.html" %}
-          {% endwith %}
-      {% endif %}
-    </div>
+  <div class="govuk-grid-column-two-thirds">
+    {% if brief_response.status == 'draft' and brief.status == 'live' %}
+      <form action="{{ url_for('.check_brief_response_answers', brief_id=brief.id, brief_response_id=brief_response.id) }}" method="post">
+        <p class="govuk-body">Once you submit you can update your application until {{ brief.applicationsClosedAt|utcdatetimeformat }}.</p>
+        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
+        {{ govukButton({"text": "Submit application"}) }}
+      </form>
+    {% else %}
+      {%
+        with
+        url = url_for(".opportunities_dashboard", framework_slug=brief.frameworkSlug),
+        text = "Your {} opportunities".format(brief.frameworkName)
+      %}
+        {% include "toolkit/secondary-action-link.html" %}
+      {% endwith %}
+    {% endif %}
   </div>
+</div>
 
-  {% endblock %}
+{% endblock %}

--- a/tests/app/main/test_briefs.py
+++ b/tests/app/main/test_briefs.py
@@ -1579,10 +1579,10 @@ class TestCheckYourAnswers(BaseApplicationTest):
         view_your_opportunities_link = doc.xpath(
             '//a[@href="{0}"][contains(normalize-space(text()), normalize-space("{1}"))]'.format(
                 "/suppliers/opportunities/frameworks/digital-outcomes-and-specialists",
-                "Your Digital Outcomes and Specialists opportunities",
+                "Return to your opportunities",
             )
         )
-        assert len(view_your_opportunities_link) == 2  # Including breadcrumb link
+        assert len(view_your_opportunities_link) == 1
 
         # Submit button and closing date paragraph are hidden
         closing_date_paragraph = doc.xpath("//main[@id='content']//form//p/text()")

--- a/tests/app/main/test_briefs.py
+++ b/tests/app/main/test_briefs.py
@@ -2038,7 +2038,7 @@ class TestResponseResultPage(BaseApplicationTest, BriefResponseTestHelpers):
                 '/suppliers/opportunities/frameworks/digital-outcomes-and-specialists'
             ),
             # ('Your response to ‘I need a thing to do a thing’', ),
-            ('Responses to ‘I need a thing to do a thing’ submitted', ),
+            ('Response to ‘I need a thing to do a thing’ submitted', ),
         ]
         self.assert_breadcrumbs(res, expected_breadcrumbs)
 


### PR DESCRIPTION
We don't need to use a template or custom CSS to insert a link.

This PR also changes the copy of the link to be clearer; thanks @aliuk2012 for the suggestion.

## Screenshots

### Before

![image](https://user-images.githubusercontent.com/503614/68597588-2116c500-0495-11ea-9b77-f4af74e68b91.png)

### After

![image](https://user-images.githubusercontent.com/503614/68597612-2e33b400-0495-11ea-9ceb-538dce3b740a.png)
