### PR TITLE
bump digitalmarketplace-utils dependency to v50.0.0

### DIFF
--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -8,7 +8,7 @@ itsdangerous==0.24 # pyup: ignore
 
 gds-metrics==0.2.0
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@48.5.0#egg=digitalmarketplace-utils==48.5.0
-git+https://github.com/alphagov/digitalmarketplace-content-loader.git@7.0.0#egg=digitalmarketplace-content-loader==7.0.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@50.0.0#egg=digitalmarketplace-utils==50.0.0
+git+https://github.com/alphagov/digitalmarketplace-content-loader.git@7.1.0#egg=digitalmarketplace-content-loader==7.1.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@21.4.0#egg=digitalmarketplace-apiclient==21.4.0
 git+https://github.com/alphagov/govuk-frontend-jinja.git@v0.5.1-alpha#egg=govuk-frontend-jinja==0.5.1-alpha

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,16 +9,16 @@ itsdangerous==0.24 # pyup: ignore
 
 gds-metrics==0.2.0
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@48.5.0#egg=digitalmarketplace-utils==48.5.0
-git+https://github.com/alphagov/digitalmarketplace-content-loader.git@7.0.0#egg=digitalmarketplace-content-loader==7.0.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@50.0.0#egg=digitalmarketplace-utils==50.0.0
+git+https://github.com/alphagov/digitalmarketplace-content-loader.git@7.1.0#egg=digitalmarketplace-content-loader==7.1.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@21.4.0#egg=digitalmarketplace-apiclient==21.4.0
 git+https://github.com/alphagov/govuk-frontend-jinja.git@v0.5.1-alpha#egg=govuk-frontend-jinja==0.5.1-alpha
 
 ## The following requirements were added by pip freeze:
 asn1crypto==1.2.0
 blinker==1.4
-boto3==1.10.14
-botocore==1.13.14
+boto3==1.10.16
+botocore==1.13.16
 certifi==2019.9.11
 cffi==1.13.2
 chardet==3.0.4
@@ -28,6 +28,7 @@ cryptography==2.3.1
 defusedxml==0.6.0
 docopt==0.6.2
 docutils==0.15.2
+Flask-gzip==0.2
 Flask-Script==2.0.6
 fleep==1.0.1
 future==0.18.2
@@ -53,7 +54,7 @@ requests==2.22.0
 s3transfer==0.2.1
 six==1.13.0
 unicodecsv==0.14.1
-urllib3==1.25.6
+urllib3==1.25.7
 Werkzeug==0.16.0
 workdays==1.4
 WTForms==2.2.1


### PR DESCRIPTION
https://trello.com/c/dz3EnMnh

This mostly brings us werkzeug 0.16.