### PR TITLE
Exclude analytics code from application.js

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -15,7 +15,6 @@
 //= require ../../../node_modules/digitalmarketplace-frontend-toolkit/toolkit/javascripts/report-a-problem.js
 //= require ../../../node_modules/digitalmarketplace-frontend-toolkit/toolkit/javascripts/user-research-consent-banner.js
 //= require ../../../node_modules/digitalmarketplace-govuk-frontend/govuk-frontend/all.js
-//= require _analytics.js
 //= require _selection-buttons.js
 
 GOVUKFrontend.initAll();

--- a/tests/app/test_application.py
+++ b/tests/app/test_application.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 
 import mock
+import pytest
 from wtforms import ValidationError
 from werkzeug.exceptions import BadRequest
 from .helpers import BaseApplicationTest
@@ -86,6 +87,8 @@ class TestApplication(BaseApplicationTest):
         assert '<p>GOV.UK uses cookies to make the site simpler. <a href="/cookies">Find ' \
             'out more about cookies</a></p>' in res.get_data(as_text=True)
 
+    # Analytics temporarily disabled
+    @pytest.mark.skip
     def test_analytics_code_should_be_in_javascript(self):
         res = self.client.get('/suppliers/opportunities/static/javascripts/application.js')
         assert res.status_code == 200


### PR DESCRIPTION
https://trello.com/c/Eth9oZbJ/203-disable-ga-cookies-temporarily

Temporarily switching off GA functionality while we review our cookie policy.

See equivalent Buyer FE PR: alphagov/digitalmarketplace-buyer-frontend#970