### PR TITLE
Fix layout overflow because wrong class was being used

### DIFF
--- a/app/templates/briefs/check_your_answers.html
+++ b/app/templates/briefs/check_your_answers.html
@@ -55,7 +55,7 @@
 </div>
 
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-one-whole">
+  <div class="govuk-grid-column-full">
     {% with show_edit_links = (brief.status == 'live' and brief_response.status in ['draft', 'submitted']) %}
       {% include 'briefs/_brief_response_data.html' %}
     {% endwith %}


### PR DESCRIPTION
When we migrated over to govuk-frontend and updating the grid we accidentally
used the wrong class name for a 100% width row. This meant that the tables overflowed outside the main page wrapper.

## Before
<img width="1057" alt="Screenshot 2020-01-02 at 13 23 41" src="https://user-images.githubusercontent.com/3441519/71669106-808da480-2d63-11ea-819f-01eb8fb7674b.png">


## After
<img width="1057" alt="Screenshot 2020-01-02 at 13 24 20" src="https://user-images.githubusercontent.com/3441519/71669095-78ce0000-2d63-11ea-93e1-35aff6d969c3.png">
