### PR TITLE
Update cookie banner

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -13,9 +13,11 @@
 //= require ../../../node_modules/digitalmarketplace-frontend-toolkit/toolkit/javascripts/shim-links-with-button-role.js
 //= require ../../../node_modules/digitalmarketplace-frontend-toolkit/toolkit/javascripts/show-hide-content.js
 //= require ../../../node_modules/digitalmarketplace-govuk-frontend/govuk-frontend/all.js
+//= require ../../../node_modules/digitalmarketplace-govuk-frontend/digitalmarketplace/digitalmarketplace-govuk-frontend.js
 //= require _selection-buttons.js
 
 GOVUKFrontend.initAll();
+DMGOVUKFrontend.initAll();
 
 (function(GOVUK, GDM) {
 

--- a/app/templates/_base_page.html
+++ b/app/templates/_base_page.html
@@ -8,6 +8,7 @@
 {% from "govuk-frontend/components/phase-banner/macro.njk" import govukPhaseBanner %}
 
 {# Import DM components #}
+{% from "digitalmarketplace/components/cookie-banner/macro.njk" import dmCookieBanner %}
 {% from "digitalmarketplace/components/header/macro.njk" import dmHeader %}
 {% from "digitalmarketplace/components/footer/macro.njk" import dmFooter %}
 
@@ -21,6 +22,12 @@
 {% endblock %}
 
 {% block header %}
+  {% block cookieBanner %}
+    {{ dmCookieBanner({
+      'cookieSettingsUrl': url_for('external.cookie_settings'),
+      'cookieInfoUrl': url_for('external.cookies'),
+    }) }}
+  {% endblock %}
   {{ dmHeader({
     "role": current_user.role | default(None)
   }) }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -2072,9 +2072,9 @@
       }
     },
     "digitalmarketplace-govuk-frontend": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/digitalmarketplace-govuk-frontend/-/digitalmarketplace-govuk-frontend-0.4.1.tgz",
-      "integrity": "sha512-SecGO1BzepmOg9z13n5ZHoRIyw1FwrhntI2y5gum3hRFkKf38MwsRHNcq0MzR8HsyIc3UsIGj2pjehJqG7rdUA=="
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/digitalmarketplace-govuk-frontend/-/digitalmarketplace-govuk-frontend-0.6.0.tgz",
+      "integrity": "sha512-JuThzUkpgeIRDFfdLnljqZcuz1Ywkzk5lsKdlsrRe20Dg0j8rEuvWhfPJU5rBtcnnyBfoLdILeOXKt55to2lsg=="
     },
     "dir-glob": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "del": "^5.1.0",
     "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#v16.0.10",
     "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v36.1.0",
-    "digitalmarketplace-govuk-frontend": "^0.4.1",
+    "digitalmarketplace-govuk-frontend": "^0.6.0",
     "govuk-elements-sass": "3.0.3",
     "govuk_frontend_toolkit": "5.0.3",
     "gulp": "^4.0.2",

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -8,7 +8,7 @@ itsdangerous==0.24 # pyup: ignore
 
 gds-metrics==0.2.0
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@51.1.0#egg=digitalmarketplace-utils==51.1.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@51.3.1#egg=digitalmarketplace-utils==51.3.1
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@7.1.1#egg=digitalmarketplace-content-loader==7.1.1
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@21.4.1#egg=digitalmarketplace-apiclient==21.4.1
 git+https://github.com/alphagov/govuk-frontend-jinja.git@v0.5.1-alpha#egg=govuk-frontend-jinja==0.5.1-alpha

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ itsdangerous==0.24 # pyup: ignore
 
 gds-metrics==0.2.0
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@51.1.0#egg=digitalmarketplace-utils==51.1.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@51.3.1#egg=digitalmarketplace-utils==51.3.1
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@7.1.1#egg=digitalmarketplace-content-loader==7.1.1
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@21.4.1#egg=digitalmarketplace-apiclient==21.4.1
 git+https://github.com/alphagov/govuk-frontend-jinja.git@v0.5.1-alpha#egg=govuk-frontend-jinja==0.5.1-alpha


### PR DESCRIPTION
https://trello.com/c/hGlNERQ6/294-3-cookie-settings-page-incl-analytics-roll-out

Introduces the new opt-in cookie banner.

See equivalent for Buyer FE alphagov/digitalmarketplace-buyer-frontend#986

- pulls in CookieBanner component from DM GOVUK Frontend
- pulls in utils fix for the new external /user/cookie-settings route
- adds banner to base page template
- reinstates a cookie banner unit test (removing a redundant test checking for old analytics JS)