### PR TITLE
Fix page title for check your answers page

### DIFF
--- a/app/templates/briefs/check_your_answers.html
+++ b/app/templates/briefs/check_your_answers.html
@@ -1,7 +1,11 @@
 {% extends "_base_page.html" %}
 
 {% block pageTitle %}
-  Your response to ‘{{ brief.title }}’ - Digital Marketplace
+  {% if brief_response.status == 'draft' %}
+    Check and submit your answers - Digital Marketplace
+  {% else %}
+    Your application for ‘{{ brief.title }}’ - Digital Marketplace
+  {% endif %}
 {% endblock %}
 
 {% block breadcrumb %}
@@ -25,7 +29,8 @@
         "text": "{}".format(brief.title)
       },
       {
-        "text": "Check your answers"
+        "text": ("Check your answers" if brief_response.status == "draft"
+                 else "Your application")
       },
     ]
   }) }}

--- a/tests/app/main/test_briefs.py
+++ b/tests/app/main/test_briefs.py
@@ -1377,11 +1377,16 @@ class TestCheckYourAnswers(BaseApplicationTest):
         else:
             assert len(edit_application_links) == 0
 
-        page_title = doc.xpath("//main//*//h1//text()")[0].strip()
+        page_title = doc.xpath("//title/text()")[0].strip()
+        page_heading = doc.xpath("//main//*//h1//text()")[0].strip()
+        breadcrumb = doc.cssselect("li.govuk-breadcrumbs__list-item:last-child")[0].text
         if brief_response_status == "draft":
-            assert page_title == "Check and submit your answers"
+            assert page_heading == "Check and submit your answers"
+            assert breadcrumb == "Check your answers"
         else:
-            assert page_title == "Your application for ‘I need a thing to do a thing’"
+            assert page_heading == "Your application for ‘I need a thing to do a thing’"
+            assert breadcrumb == "Your application"
+        assert page_title == page_heading + " - Digital Marketplace"
 
     @pytest.mark.parametrize('brief_response_status', ['pending-awarded', 'awarded'])
     @pytest.mark.parametrize('brief_status', ['live', 'closed', 'awarded', 'unsuccessful', 'cancelled'])


### PR DESCRIPTION
Ticket: https://trello.com/c/zzrRBDzm/1365-page-title-on-brief-response-check-your-answers-page-doesnt-match-content

The page title should be the same as the page heading, and different from the page title for other pages