### PR TITLE
Install digitalmarketplace-govuk-frontend and govuk-frontend separately

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,6 +61,7 @@ node_modules
 npm-debug.log
 app/templates/govuk
 app/templates/toolkit
+app/assets/scss/govuk
 app/assets/scss/toolkit
 app/content
 

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "package-lock.json",
     "lines": null
   },
-  "generated_at": "2020-08-28T08:59:03Z",
+  "generated_at": "2020-09-04T10:09:39Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -63,7 +63,7 @@
         "hashed_secret": "6ece33acdf8a843e90915a2b661ab55941348059",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 88,
+        "line_number": 94,
         "type": "Secret Keyword"
       }
     ]

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -12,7 +12,7 @@
 //= require ../../../node_modules/govuk_frontend_toolkit/javascripts/govuk/shim-links-with-button-role.js
 //= require ../../../node_modules/digitalmarketplace-frontend-toolkit/toolkit/javascripts/shim-links-with-button-role.js
 //= require ../../../node_modules/digitalmarketplace-frontend-toolkit/toolkit/javascripts/show-hide-content.js
-//= require ../../../node_modules/digitalmarketplace-govuk-frontend/govuk/all.js
+//= require ../../../node_modules/govuk-frontend/all.js
 //= require ../../../node_modules/digitalmarketplace-govuk-frontend/digitalmarketplace/all.js
 //= require _selection-buttons.js
 

--- a/app/assets/scss/application.scss
+++ b/app/assets/scss/application.scss
@@ -44,7 +44,7 @@ $govuk-compatibility-govukelements: true;
 // https://github.com/alphagov/govuk-frontend/blob/v2.13.0/src/settings/_global-styles.scss
 // https://github.com/alphagov/govuk-frontend/blob/v2.13.0/src/core/_global-styles.scss
 $govuk-global-styles: true;
-@import "node_modules/digitalmarketplace-govuk-frontend/govuk/all";
+@import "node_modules/govuk-frontend/all";
 
 // Digital Marketplace Components
 @import "node_modules/digitalmarketplace-govuk-frontend/digitalmarketplace/all";

--- a/config.py
+++ b/config.py
@@ -55,12 +55,18 @@ class Config(object):
     def init_app(app):
         repo_root = os.path.abspath(os.path.dirname(__file__))
         digitalmarketplace_govuk_frontend = os.path.join(repo_root, "node_modules", "digitalmarketplace-govuk-frontend")
+        govuk_frontend = os.path.join(repo_root, "node_modules", "govuk-frontend")
+
         template_folders = [
             os.path.join(repo_root, "app", "templates"),
             os.path.join(digitalmarketplace_govuk_frontend),
             os.path.join(digitalmarketplace_govuk_frontend, "digitalmarketplace", "templates"),
         ]
-        jinja_loader = jinja2.FileSystemLoader(template_folders)
+
+        jinja_loader = jinja2.ChoiceLoader([
+            jinja2.FileSystemLoader(template_folders),
+            jinja2.PrefixLoader({"govuk": jinja2.FileSystemLoader(govuk_frontend)}),
+        ])
         app.jinja_loader = jinja_loader
 
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -14,7 +14,7 @@ const repoRoot = path.join(__dirname)
 const npmRoot = path.join(repoRoot, 'node_modules')
 const govukToolkitRoot = path.join(npmRoot, 'govuk_frontend_toolkit')
 const govukElementsRoot = path.join(npmRoot, 'govuk-elements-sass')
-const govukFrontendRoot = path.join(npmRoot, 'digitalmarketplace-govuk-frontend', 'govuk')
+const govukFrontendRoot = path.join(npmRoot, 'govuk-frontend')
 const dmToolkitRoot = path.join(npmRoot, 'digitalmarketplace-frontend-toolkit', 'toolkit')
 const sspContentRoot = path.join(npmRoot, 'digitalmarketplace-frameworks')
 const assetsFolder = path.join(repoRoot, 'app', 'assets')
@@ -213,6 +213,18 @@ gulp.task(
   )
 )
 
+gulp.task(
+  'copy:govuk_frontend_assets:stylesheets',
+  function () {
+    return gulp
+      .src(path.join(govukFrontendRoot, '**', '*.scss'), { base: govukFrontendRoot })
+      .pipe(gulp.dest(path.join('app', 'assets', 'scss', 'govuk')))
+      .on('end', function () {
+        console.log('📂  Copied stylesheets from GOV.UK Frontend')
+      })
+  }
+)
+
 gulp.task('set_environment_to_development', function (cb) {
   environment = 'development'
   cb()
@@ -233,7 +245,8 @@ gulp.task(
     'copy:dm_toolkit_assets:templates',
     'copy:images',
     'copy:govuk_frontend_assets:fonts',
-    'copy:govuk_frontend_assets:images'
+    'copy:govuk_frontend_assets:images',
+    'copy:govuk_frontend_assets:stylesheets'
   )
 )
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -3993,6 +3993,11 @@
         }
       }
     },
+    "govuk-frontend": {
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-2.13.0.tgz",
+      "integrity": "sha512-6XDtTt5plSrPQvPgLFN4LCtb9ULuqoXCgkHy5c7XE/70/sVm47RPbLR11tYGPcmV8cOApBhW0wL8y8ryspHfpw=="
+    },
     "govuk_frontend_toolkit": {
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/govuk_frontend_toolkit/-/govuk_frontend_toolkit-5.0.3.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2075,9 +2075,9 @@
       }
     },
     "digitalmarketplace-govuk-frontend": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/digitalmarketplace-govuk-frontend/-/digitalmarketplace-govuk-frontend-1.0.1.tgz",
-      "integrity": "sha512-hjphImLlHhNOyF2HUuOu1RHM3i2ZlEim44hbakeW2PCRIATD8Y3Kw4Z4oiSgNXN0DdjMDiJ4ic8czGGQdhr7lQ=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/digitalmarketplace-govuk-frontend/-/digitalmarketplace-govuk-frontend-2.0.0.tgz",
+      "integrity": "sha512-A3+j/gLT9NzOniffAmuHqx1cEfHb8MpfV0/LR4//taZAsigdabqoNRKD2/B0oZdNuRDOEBHtUywQEbEomADIaA=="
     },
     "dir-glob": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "del": "^5.1.0",
     "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#v16.0.10",
     "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v36.1.0",
-    "digitalmarketplace-govuk-frontend": "^1.0.1",
+    "digitalmarketplace-govuk-frontend": "^2.0.0",
     "govuk-elements-sass": "3.0.3",
     "govuk_frontend_toolkit": "5.0.3",
     "gulp": "^4.0.2",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v36.1.0",
     "digitalmarketplace-govuk-frontend": "^2.0.0",
     "govuk-elements-sass": "3.0.3",
+    "govuk-frontend": "^2.13.0",
     "govuk_frontend_toolkit": "5.0.3",
     "gulp": "^4.0.2",
     "gulp-filelog": "0.4.1",


### PR DESCRIPTION
https://trello.com/c/fhL8Zl8T/175-3-unbundle-govuk-frontend-from-digitalmarketplace-govuk-frontend

digitalmarketplace-govuk-frontend has been updated so that it is no longer bundled with govuk-frontend.

This PR addresses those changes.