### PR TITLE
set DM_REDIS_SERVICE_NAME to None

### DIFF
--- a/config.py
+++ b/config.py
@@ -27,6 +27,7 @@ class Config(object):
     DM_DATA_API_URL = None
     DM_DATA_API_AUTH_TOKEN = None
     DM_NOTIFY_API_KEY = None
+    DM_REDIS_SERVICE_NAME = None
 
     DEBUG = False
 


### PR DESCRIPTION
https://trello.com/c/0XO8CHaP/381-05-stand-up-the-paas-infrastructure-for-the-preview-environment

We need to set this to `None` to stop it getting stripped out of the app config when set in an environment variable

Co-authored-by: Benjamin Gill <benjamin.gill@digital.cabinet-office.gov.uk>pr