### PR TITLE
Replace validation banners

### DIFF
--- a/app/main/forms/briefs.py
+++ b/app/main/forms/briefs.py
@@ -19,10 +19,10 @@ class AskClarificationQuestionForm(FlaskForm):
             Read more about <a class="govuk-link" href="{guidance_url}">how supplier questions are managed</a>.
             """
         ),
-        validators=[validators.DataRequired(message='Question cannot be empty'),
-                    validators.Length(max=5000, message='Question cannot be longer than 5000 characters'),
+        validators=[validators.DataRequired(message='Enter your question'),
+                    validators.Length(max=5000, message='Your question must be 5000 characters or fewer'),
                     validators.Regexp(regex="^$|(^(?:\\S+\\s+){0,99}\\S+$)",
-                                      message='Question must be no more than 100 words')],
+                                      message='Your question must be 100 words or fewer')],
         widget=DMTextArea(max_length_in_words=100),
     )
 

--- a/app/main/views/briefs.py
+++ b/app/main/views/briefs.py
@@ -202,7 +202,7 @@ def edit_brief_response(brief_id, brief_response_id, question_id=None):
             )
 
         except HTTPError as e:
-            errors = question.get_error_messages(e.message)
+            errors = govuk_errors(question.get_error_messages(e.message))
             status_code = 400
             service_data = question.unformat_data(question.get_data(request.form))
 

--- a/app/main/views/briefs.py
+++ b/app/main/views/briefs.py
@@ -7,6 +7,7 @@ from flask_login import current_user
 from dmapiclient import HTTPError
 from dmutils.flask import timed_render_template as render_template
 from dmutils.forms.helpers import get_errors_from_wtform
+from dmutils.forms.errors import govuk_errors
 
 from ..helpers.briefs import (
     get_brief,
@@ -60,7 +61,7 @@ def ask_brief_clarification_question(brief_id):
         form_url = url_for('.ask_brief_clarification_question', brief_id=brief_id)
         flash('{}?submitted=true'.format(form_url), 'track-page-view')
 
-    errors = get_errors_from_wtform(form)
+    errors = govuk_errors(get_errors_from_wtform(form))
 
     return render_template(
         "briefs/clarification_question.html",

--- a/app/main/views/briefs.py
+++ b/app/main/views/briefs.py
@@ -203,6 +203,12 @@ def edit_brief_response(brief_id, brief_response_id, question_id=None):
 
         except HTTPError as e:
             errors = govuk_errors(question.get_error_messages(e.message))
+            # Temporary fix to handle the multiple yesNo questions on niceToHaveRequirements
+            # This will be handled in content loader when this form uses govuk_frontend
+            # TODO: Remove this for loop when this form uses govuk_frontend
+            for key in errors:
+                if key.startswith('yesNo'):
+                    errors[key]['href'] += '-1'
             status_code = 400
             service_data = question.unformat_data(question.get_data(request.form))
 

--- a/app/templates/_base_page.html
+++ b/app/templates/_base_page.html
@@ -14,6 +14,10 @@
 
 {% set assetPath = '/suppliers/opportunities/static' %}
 
+{% block pageTitle %}
+  {% if errors %}Error: {% endif %}{{ page_name }} - Digital Marketplace
+{% endblock %}
+
 {% block head %}
   {% include "layouts/_custom_dimensions.html" %}
   {% include "layouts/_site_verification.html" %}
@@ -45,6 +49,14 @@
 
 {% block content %}
   {% include "toolkit/flash_messages.html" %}
+  {% block errorSummary %}
+    {% if errors %}
+      {{ govukErrorSummary({
+      "titleText": "There is a problem",
+      "errorList": errors.values(),
+    }) }}
+    {% endif %}
+  {% endblock %}
   {% block mainContent %}{% endblock %}
 {% endblock %}
 

--- a/app/templates/briefs/_base_edit_question_page.html
+++ b/app/templates/briefs/_base_edit_question_page.html
@@ -1,13 +1,9 @@
 {% extends "_base_page.html" %}
 {% import "toolkit/forms/macros/forms.html" as forms %}
 
-{% block pageTitle %}
-  {{ question.question }} – Digital Marketplace
-{% endblock %}
+{% set page_name = question.question %}
 
 {% block mainContent %}
-
-  {% include 'toolkit/forms/validation.html' %}
 
   {% if question.type != 'multiquestion' %}
     <div class="single-question-page">
@@ -15,7 +11,6 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-
       <h1 class="govuk-heading-l">{{ question.question }}</h1>
     </div>
   </div>

--- a/app/templates/briefs/clarification_question.html
+++ b/app/templates/briefs/clarification_question.html
@@ -1,8 +1,6 @@
 {% extends "_base_page.html" %}
 
-{% block pageTitle %}
-  Ask a question about ‘{{ brief.title }}’ – Digital Marketplace
-{% endblock %}
+{% set page_name = "Ask a question about ‘{{ brief.title }}’" %}
 
 {% block breadcrumb %}
 
@@ -25,10 +23,6 @@
 {% endblock %}
 
 {% block mainContent %}
-
-{% with lede = "There was a problem with your submitted question" %}
-  {% include "toolkit/forms/validation.html" %}
-{% endwith %}
 
 <div class="single-question-page">
   <div class="govuk-grid-row">

--- a/package-lock.json
+++ b/package-lock.json
@@ -2063,8 +2063,8 @@
       "dev": true
     },
     "digitalmarketplace-frameworks": {
-      "version": "git+https://github.com/alphagov/digitalmarketplace-frameworks.git#960bc2709719ee31e77a5bbe4503de6a846d23ae",
-      "from": "git+https://github.com/alphagov/digitalmarketplace-frameworks.git#v16.0.10"
+      "version": "git+https://github.com/alphagov/digitalmarketplace-frameworks.git#a01bcb95820cf7190cf6feb1b0407fc10d25e3e8",
+      "from": "git+https://github.com/alphagov/digitalmarketplace-frameworks.git#v18.0.2"
     },
     "digitalmarketplace-frontend-toolkit": {
       "version": "git+https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#323b3d4b704e33782df6cdae7b105a2a9237a594",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "colors": "1.1.2",
     "del": "^5.1.0",
-    "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#v16.0.10",
+    "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#v18.0.2",
     "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v36.1.0",
     "digitalmarketplace-govuk-frontend": "^2.1.0",
     "govuk-elements-sass": "3.0.3",

--- a/requirements.in
+++ b/requirements.in
@@ -9,6 +9,6 @@ itsdangerous==1.1.0
 gds-metrics==0.2.4
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@56.0.0#egg=digitalmarketplace-utils==56.0.0
-git+https://github.com/alphagov/digitalmarketplace-content-loader.git@7.1.1#egg=digitalmarketplace-content-loader==7.1.1
+git+https://github.com/alphagov/digitalmarketplace-content-loader.git@7.27.0#egg=digitalmarketplace-content-loader==7.27.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@21.4.1#egg=digitalmarketplace-apiclient==21.4.1
 git+https://github.com/alphagov/govuk-frontend-jinja.git@v0.5.1-alpha#egg=govuk-frontend-jinja==0.5.1-alpha

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ contextlib2==0.6.0.post1  # via digitalmarketplace-utils
 cryptography==3.2.1       # via digitalmarketplace-utils
 defusedxml==0.6.0         # via odfpy
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@21.4.1#egg=digitalmarketplace-apiclient==21.4.1  # via -r requirements.in
-git+https://github.com/alphagov/digitalmarketplace-content-loader.git@7.1.1#egg=digitalmarketplace-content-loader==7.1.1  # via -r requirements.in
+git+https://github.com/alphagov/digitalmarketplace-content-loader.git@7.27.0#egg=digitalmarketplace-content-loader==7.27.0  # via -r requirements.in
 git+https://github.com/alphagov/digitalmarketplace-utils.git@56.0.0#egg=digitalmarketplace-utils==56.0.0  # via -r requirements.in, digitalmarketplace-content-loader
 docopt==0.6.2             # via notifications-python-client
 docutils==0.15.2          # via botocore


### PR DESCRIPTION
https://trello.com/c/x5aacZhG/282-1-replace-validation-banner-with-govuk-frontend-error-summary-component-in-the-brief-responses-frontend

It was a bit tricky to know where to bound this ticket, as there were a few issues with `boolean` type questions (https://github.com/alphagov/digitalmarketplace-content-loader/pull/119) and with the focus of Error Summary links.

Since the content loader ticket (https://trello.com/c/13tOvxuu/285-2-replace-content-loader-form-macros-in-brief-responses-frontend) should take care of the focus issues for most questions, my strategy is to keep this a separate concern and not fix the focus issues (specifically, that clicking on a link in the Error Summary can pull focus to the question but not show the question title, since it's been separately set as the page header).

Then we can handle those in the other ticket and release both PRs together.

### digitalmarketplace-frameworks
This PR relies on some content changes to the frameworks repo, for validation messages: https://github.com/alphagov/digitalmarketplace-frameworks/pull/656