### PR TITLE
Replace content loader macros

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -6,6 +6,7 @@ from flask_wtf.csrf import CSRFProtect, CSRFError
 
 
 import dmapiclient
+import dmcontent.govuk_frontend
 from dmutils import init_app
 from dmutils.user import User
 from dmutils.external import external as external_blueprint
@@ -56,6 +57,11 @@ def create_app(config_name):
     # https://github.com/alphagov/gds_metrics_python/issues/4
     gds_metrics.init_app(application)
     csrf.init_app(application)
+
+    # We want to be able to access this function from within all templates
+    application.jinja_env.globals["govuk_frontend_from_question"] = (
+        dmcontent.govuk_frontend.from_question
+    )
 
     @application.before_request
     def remove_trailing_slash():

--- a/app/assets/scss/application.scss
+++ b/app/assets/scss/application.scss
@@ -54,6 +54,7 @@ $govuk-global-styles: true;
 
 // Overrides
 @import "overrides/_notification-banner";
+@import "overrides/_pricing-input";
 
 // Misc styles
 // TODO: Move misc styling into their own partial files or the Digital Marketplace FE Toolkit

--- a/app/assets/scss/overrides/_pricing-input.scss
+++ b/app/assets/scss/overrides/_pricing-input.scss
@@ -1,0 +1,13 @@
+.dm-pricing-question {
+  .question {
+      margin-top: 0;
+  }
+
+  .question-advice {
+      padding-top: 0;
+  }
+
+  .question-heading {
+      @extend %visually-hidden;
+  }
+}

--- a/app/templates/briefs/_base_edit_question_page.html
+++ b/app/templates/briefs/_base_edit_question_page.html
@@ -1,11 +1,12 @@
 {% extends "_base_page.html" %}
+{% import "toolkit/forms/macros/forms.html" as forms %}
 {% import "macros/show_question.html" as show_question %}
 
 {% set page_name = question.question %}
 
 {% block mainContent %}
 
-  {% if question.type == 'multiquestion' %}
+  {% if question.type == 'multiquestion' or question.type == 'pricing' %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-l">
@@ -19,20 +20,30 @@
 
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
-        {% if question.type != 'multiquestion' %}
-          {{ show_question.show_question(question, service_data, errors) }}
+        {% if question.type == 'pricing' %}
+          <div class="dm-pricing-question">
+            {% if errors and errors[question.id] %}
+              {{ forms[question.type](question, service_data, errors) }}
+            {% else %}
+              {{ forms[question.type](question, service_data, {}) }}
+            {% endif %}
+          </div>
         {% else %}
-          {% if question.question_advice %}
-            <span class="question-advice">
-              {{ question.question_advice }}
-            </span>
+          {% if question.type != 'multiquestion' %}
+            {{ show_question.show_question(question, service_data, errors) }}
+          {% else %}
+            {% if question.question_advice %}
+              <span class="question-advice">
+                {{ question.question_advice }}
+              </span>
+            {% endif %}
+            {% for question in question.questions %}
+              {{ show_question.show_question(question, service_data, errors, is_only_question=False) }}
+            {% endfor %}
           {% endif %}
-          {% for question in question.questions %}
-            {{ show_question.show_question(question, service_data, errors, is_only_question=False) }}
-          {% endfor %}
         {% endif %}
-        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
-        {% block save_button %}{% endblock %}
+          <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
+          {% block save_button %}{% endblock %}
       </div>
     </div>
 

--- a/app/templates/briefs/_base_edit_question_page.html
+++ b/app/templates/briefs/_base_edit_question_page.html
@@ -1,55 +1,40 @@
 {% extends "_base_page.html" %}
-{% import "toolkit/forms/macros/forms.html" as forms %}
+{% import "macros/show_question.html" as show_question %}
 
 {% set page_name = question.question %}
 
 {% block mainContent %}
 
-  {% if question.type != 'multiquestion' %}
-    <div class="single-question-page">
-  {% endif %}
-
+  {% if question.type == 'multiquestion' %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <h1 class="govuk-heading-l">{{ question.question }}</h1>
+      <h1 class="govuk-heading-l">
+        {{ question.question }}
+      </h1>
     </div>
   </div>
+  {% endif %}
 
   <form method="post" enctype="multipart/form-data" action="{{ request.path }}">
 
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
-          {% if question.type != 'multiquestion' %}
-            {% if errors and errors[question.id] %}
-              {{ forms[question.type](question, service_data, errors) }}
-            {% else %}
-              {{ forms[question.type](question, service_data, {}) }}
-            {% endif %}
-          {% else %}
-            {% if question.question_advice %}
-              <div class="dmspeak">
-                <span class="question-advice">
-                  {{ question.question_advice }}
-                </span>
-              </div>
-            {% endif %}
-            {% for question in question.questions %}
-              {% if errors and errors[question.id] %}
-                {{ forms[question.type](question, service_data, errors) }}
-              {% else %}
-                {{ forms[question.type](question, service_data, {}) }}
-              {% endif %}
-            {% endfor %}
+        {% if question.type != 'multiquestion' %}
+          {{ show_question.show_question(question, service_data, errors) }}
+        {% else %}
+          {% if question.question_advice %}
+            <span class="question-advice">
+              {{ question.question_advice }}
+            </span>
           {% endif %}
-          <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
-          {% block save_button %}{% endblock %}
-
+          {% for question in question.questions %}
+            {{ show_question.show_question(question, service_data, errors, is_only_question=False) }}
+          {% endfor %}
+        {% endif %}
+        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
+        {% block save_button %}{% endblock %}
       </div>
     </div>
 
   </form>
-
-  {% if question.type != 'multiquestion' %}
-    </div>
-  {% endif %}
 {% endblock %}

--- a/app/templates/briefs/_base_edit_question_page.html
+++ b/app/templates/briefs/_base_edit_question_page.html
@@ -6,46 +6,95 @@
 
 {% block mainContent %}
 
-  {% if question.type == 'multiquestion' or question.type == 'pricing' %}
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-      <h1 class="govuk-heading-l">
-        {{ question.question }}
-      </h1>
-    </div>
-  </div>
-  {% endif %}
+  <!-- Pricing questions use a prefix, which is available in govuk-frontend v3, but not in v2. -->
+  <!-- niceToHaveRequirements uses followup/reveal questions which are not in scope -->
+  {% if question.type == 'pricing' or question.id == 'niceToHaveRequirements' %}
 
-  <form method="post" enctype="multipart/form-data" action="{{ request.path }}">
+    {% if question.type != 'multiquestion' %}
+      <div class="single-question-page">
+    {% endif %}
 
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
-        {% if question.type == 'pricing' %}
-          <div class="dm-pricing-question">
-            {% if errors and errors[question.id] %}
-              {{ forms[question.type](question, service_data, errors) }}
+        <h1 class="govuk-heading-l">{{ question.question }}</h1>
+      </div>
+    </div>
+
+    <form method="post" enctype="multipart/form-data" action="{{ request.path }}">
+
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            {% if question.type != 'multiquestion' %}
+              {% if errors and errors[question.id] %}
+                {{ forms[question.type](question, service_data, errors) }}
+              {% else %}
+                {{ forms[question.type](question, service_data, {}) }}
+              {% endif %}
             {% else %}
-              {{ forms[question.type](question, service_data, {}) }}
+              {% if question.question_advice %}
+                <div class="dmspeak">
+                  <span class="question-advice">
+                    {{ question.question_advice }}
+                  </span>
+                </div>
+              {% endif %}
+              {% for question in question.questions %}
+                {% if errors and errors[question.id] %}
+                  {{ forms[question.type](question, service_data, errors) }}
+                {% else %}
+                  {{ forms[question.type](question, service_data, {}) }}
+                {% endif %}
+              {% endfor %}
             {% endif %}
-          </div>
-        {% else %}
+            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
+            {{ govukButton({"text": "Save and continue"}) }}
+            {% if previous_question_url %}
+              <p class="govuk-body">
+                <a class="govuk-link" href="{{ previous_question_url }}">Back to previous page</a>
+              </p>
+            {% endif %}
+
+        </div>
+      </div>
+
+    </form>
+
+    {% if question.type != 'multiquestion' %}
+      </div>
+    {% endif %}
+
+  {% else %}
+
+    {% if question.type == 'multiquestion' %}
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        <h1 class="govuk-heading-l">
+          {{ question.question }}
+        </h1>
+      </div>
+    </div>
+    {% endif %}
+
+    <form method="post" enctype="multipart/form-data" action="{{ request.path }}">
+
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
           {% if question.type != 'multiquestion' %}
             {{ show_question.show_question(question, service_data, errors) }}
           {% else %}
             {% if question.question_advice %}
-              <span class="question-advice">
-                {{ question.question_advice }}
-              </span>
+              {{ question.question_advice }}
             {% endif %}
             {% for question in question.questions %}
               {{ show_question.show_question(question, service_data, errors, is_only_question=False) }}
             {% endfor %}
           {% endif %}
-        {% endif %}
           <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
           {% block save_button %}{% endblock %}
+        </div>
       </div>
-    </div>
 
-  </form>
+    </form>
+  
+  {% endif %}
 {% endblock %}

--- a/app/templates/briefs/start_brief_response.html
+++ b/app/templates/briefs/start_brief_response.html
@@ -39,34 +39,30 @@
   %}
 
   <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds dmspeak">
-    <h1 class="govuk-heading-l">Before you start</h1>
-      
-      <div class="explanation-list">
-        <p class="govuk-body">To apply for this opportunity, you’ll need to:</p>
-        <ul class="govuk-list govuk-list--bullet">
-          <li>give the date {{ lot_content[brief.lotSlug][0] }} will be available to start work</li>
-          {% if brief.lotSlug == "digital-specialists" %}
-            <li>provide the specialist's day rate</li>
-          {% endif %}
-          <li>say which skills and experience {{ lot_content[brief.lotSlug][0] }} {{ lot_content[brief.lotSlug][1] }}</li>
-          <li>give evidence for all the skills and experience {{ lot_content[brief.lotSlug][0] }} {{ lot_content[brief.lotSlug][1] }}</li>
-        </ul>
-      </div>
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-l">Before you start</h1>
 
-      <h2 class="heading-xmedium">How to give evidence</h2>
+      <p class="govuk-body">To apply for this opportunity, you’ll need to:</p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>give the date {{ lot_content[brief.lotSlug][0] }} will be available to start work</li>
+        {% if brief.lotSlug == "digital-specialists" %}
+          <li>provide the specialist's day rate</li>
+        {% endif %}
+        <li>say which skills and experience {{ lot_content[brief.lotSlug][0] }} {{ lot_content[brief.lotSlug][1] }}</li>
+        <li>give evidence for all the skills and experience {{ lot_content[brief.lotSlug][0] }} {{ lot_content[brief.lotSlug][1] }}</li>
+      </ul>
+
+      <h2 class="govuk-heading-m">How to give evidence</h2>
       <p class="govuk-body">The buyer will assess and score your evidence to shortlist the best {% if brief.lotSlug == 'digital-specialists' %}specialists{% else %}suppliers{% endif %}.</p>
       <p class="govuk-body">You’ll need to meet or exceed their essential requirements to get through to the next stage.</p>
 
-      <h3 class="heading-small">Evidence structure</h3>
-      <div class="explanation-list padding-bottom-small">
-        <p class="govuk-body">When you write your evidence, you should be specific about:</p>
-        <ul class="govuk-list govuk-list--bullet">
-          <li>what the situation was</li>
-          <li>the work {{ lot_content[brief.lotSlug][0] }} did</li>
-          <li>what the results were</li>
-        </ul>
-      </div>
+      <h3 class="govuk-heading-s">Evidence structure</h3>
+      <p class="govuk-body">When you write your evidence, you should be specific about:</p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>what the situation was</li>
+        <li>the work {{ lot_content[brief.lotSlug][0] }} did</li>
+        <li>what the results were</li>
+      </ul>
       <p class="govuk-body">There’s a 100-word maximum for each essential or nice-to-have requirement.</p>
       <p class="govuk-body">You should only provide one example for each essential or nice-to-have requirement (unless the buyer specifies otherwise).</p>
       <p class="govuk-body">You can reuse examples across different essential or nice-to-have requirements if you need to.</p>

--- a/app/templates/macros/show_question.html
+++ b/app/templates/macros/show_question.html
@@ -1,0 +1,38 @@
+{% from "govuk/components/input/macro.njk" import govukInput %}
+{% from "govuk/components/fieldset/macro.njk" import govukFieldset %}
+{% from "govuk/components/label/macro.njk" import govukLabel %}
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
+{% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
+{% from "govuk/components/date-input/macro.njk" import govukDateInput %}
+
+{% from "govuk/components/character-count/macro.njk" import govukCharacterCount %}
+{% from "digitalmarketplace/components/list-input/macro.njk" import dmListInput %}
+
+{%- macro show_question(question, brief, errors, is_only_question=True) %}
+  {% set form = govuk_frontend_from_question(question, brief, errors, is_page_heading=is_only_question) %}
+  {% set govuk_forms = {
+    "govukInput": govukInput, 
+    "govukRadios": govukRadios,
+    "govukCheckboxes": govukCheckboxes,
+    "govukDateInput": govukDateInput, 
+    "dmListInput": dmListInput, 
+    "govukCharacterCount": govukCharacterCount
+  } %}
+  {%- if form.label %}
+    {{ govukLabel(form.label) }}
+  {% endif -%}
+  {% if form.fieldset %}
+    {% call govukFieldset(form.fieldset) %}
+      {% if not form.params.question_advice %}
+        {{ question.question_advice }}
+      {% endif %}
+      {{ govuk_forms[form.macro_name](form.params) }}
+    {% endcall %}
+  {% else %}
+    {% if not form.params.question_advice %}
+      {{ question.question_advice }}
+    {% endif %}
+    {{ form.params }}
+    {{ govuk_forms[form.macro_name](form.params) }}
+  {% endif %}
+{% endmacro -%}

--- a/app/templates/macros/show_question.html
+++ b/app/templates/macros/show_question.html
@@ -32,7 +32,6 @@
     {% if not form.params.question_advice %}
       {{ question.question_advice }}
     {% endif %}
-    {{ form.params }}
     {{ govuk_forms[form.macro_name](form.params) }}
   {% endif %}
 {% endmacro -%}

--- a/package-lock.json
+++ b/package-lock.json
@@ -2063,8 +2063,8 @@
       "dev": true
     },
     "digitalmarketplace-frameworks": {
-      "version": "git+https://github.com/alphagov/digitalmarketplace-frameworks.git#a01bcb95820cf7190cf6feb1b0407fc10d25e3e8",
-      "from": "git+https://github.com/alphagov/digitalmarketplace-frameworks.git#v18.0.2"
+      "version": "git+https://github.com/alphagov/digitalmarketplace-frameworks.git#8578fc0abd5581a6c375a3712bdca904ce5a9673",
+      "from": "git+https://github.com/alphagov/digitalmarketplace-frameworks.git#v18.0.5"
     },
     "digitalmarketplace-frontend-toolkit": {
       "version": "git+https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#323b3d4b704e33782df6cdae7b105a2a9237a594",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "colors": "1.1.2",
     "del": "^5.1.0",
-    "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#v18.0.2",
+    "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#v18.0.5",
     "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v36.1.0",
     "digitalmarketplace-govuk-frontend": "^2.9.0",
     "govuk-elements-sass": "3.0.3",

--- a/requirements.in
+++ b/requirements.in
@@ -9,6 +9,6 @@ itsdangerous==1.1.0
 gds-metrics==0.2.4
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@56.0.0#egg=digitalmarketplace-utils==56.0.0
-git+https://github.com/alphagov/digitalmarketplace-content-loader.git@7.27.0#egg=digitalmarketplace-content-loader==7.27.0
+git+https://github.com/alphagov/digitalmarketplace-content-loader.git@7.27.1#egg=digitalmarketplace-content-loader==7.27.1
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@21.4.1#egg=digitalmarketplace-apiclient==21.4.1
 git+https://github.com/alphagov/govuk-frontend-jinja.git@v0.5.1-alpha#egg=govuk-frontend-jinja==0.5.1-alpha

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ contextlib2==0.6.0.post1  # via digitalmarketplace-utils
 cryptography==3.2.1       # via digitalmarketplace-utils
 defusedxml==0.6.0         # via odfpy
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@21.4.1#egg=digitalmarketplace-apiclient==21.4.1  # via -r requirements.in
-git+https://github.com/alphagov/digitalmarketplace-content-loader.git@7.27.0#egg=digitalmarketplace-content-loader==7.27.0  # via -r requirements.in
+git+https://github.com/alphagov/digitalmarketplace-content-loader.git@7.27.1#egg=digitalmarketplace-content-loader==7.27.1  # via -r requirements.in
 git+https://github.com/alphagov/digitalmarketplace-utils.git@56.0.0#egg=digitalmarketplace-utils==56.0.0  # via -r requirements.in, digitalmarketplace-content-loader
 docopt==0.6.2             # via notifications-python-client
 docutils==0.15.2          # via botocore

--- a/tests/app/main/test_briefs.py
+++ b/tests/app/main/test_briefs.py
@@ -766,16 +766,12 @@ class TestApplyToBrief(BaseApplicationTest):
         assert res.status_code == 200
 
         doc = html.fromstring(res.get_data(as_text=True))
-        day_rate_headings = doc.xpath("//*[@id='input-dayRate-question-advice']/h2/text()")
-        buyers_max_day_rate = doc.xpath(
-            "//*[@id='input-dayRate-question-advice']/descendant::h2[1]/following::p[1]/text()")[0]
-        suppliers_max_day_rate = doc.xpath(
-            "//*[@id='input-dayRate-question-advice']/descendant::h2[2]/following::p[1]/text()")[0]
+        day_rates = doc.xpath("//*[@id='input-dayRate-question-advice']/p/text()")
 
-        assert day_rate_headings[0] == "Buyer’s maximum day rate:"
-        assert buyers_max_day_rate == '1 million dollars'
-        assert day_rate_headings[1] == "Your maximum day rate:"
-        assert suppliers_max_day_rate == '£600'
+        assert day_rates[0].strip() == "Buyer’s maximum day rate:"
+        assert day_rates[1].strip() == "1 million dollars"
+        assert day_rates[2].strip() == "Your maximum day rate:"
+        assert day_rates[3].strip() == "£600"
 
     def test_day_rate_question_escapes_brief_day_rate_markdown(self):
         self.brief['briefs']['budgetRange'] = '**markdown**'

--- a/tests/app/main/test_briefs.py
+++ b/tests/app/main/test_briefs.py
@@ -772,7 +772,7 @@ class TestApplyToBrief(BaseApplicationTest):
         suppliers_max_day_rate = doc.xpath(
             "//*[@id='input-dayRate-question-advice']/descendant::h2[2]/following::p[1]/text()")[0]
 
-        assert day_rate_headings[0] == "Buyer's maximum day rate:"
+        assert day_rate_headings[0] == "Buyer’s maximum day rate:"
         assert buyers_max_day_rate == '1 million dollars'
         assert day_rate_headings[1] == "Your maximum day rate:"
         assert suppliers_max_day_rate == '£600'
@@ -810,7 +810,7 @@ class TestApplyToBrief(BaseApplicationTest):
         )
         assert res.status_code == 200
         data = res.get_data(as_text=True)
-        assert "Buyer's maximum day rate:" not in data
+        assert "Buyer’s maximum day rate:" not in data
 
     def test_availability_question_shows_correct_content_for_lot(self):
         self.brief['briefs']['startDate'] = '17/01/2017'
@@ -1077,13 +1077,13 @@ class TestApplyToBrief(BaseApplicationTest):
         )
         assert res.status_code == 200
         doc = html.fromstring(res.get_data(as_text=True))
-        boolean_qs = list(map(str.strip, doc.xpath("//legend[contains(@class,'govuk-fieldset__legend')]/text()")))
+        questions = doc.xpath(
+            "//*[@class='question-heading']/text()")
+        questions = list(map(str.strip, questions))
 
-        assert boolean_qs == ['Nice one', 'Top one', 'Get sorted']
-
-        evidence_qs = list(map(str.strip, doc.xpath("//label[contains(@for,'input-evidence')]/text()")))
-
-        assert evidence_qs == ['Evidence of Nice one', 'Evidence of Top one', 'Evidence of Get sorted']
+        assert questions == [
+            'Nice one', 'Evidence of Nice one', 'Top one', 'Evidence of Top one', 'Get sorted', 'Evidence of Get sorted'
+        ]
 
     def test_existing_nice_to_have_requirements_evidence_prefills_existing_data(self):
         self.data_api_client.get_brief_response.return_value = self.brief_response(
@@ -1174,15 +1174,15 @@ class TestApplyToBrief(BaseApplicationTest):
                 'Your answer must be 100 words or fewer')
 
         # Test individual questions errors and prefilled content
-        assert (doc.cssselect(".govuk-error-message")[0].text_content().strip() ==
-                'Error: Select yes if you have evidence of Nice one')
+        assert (doc.xpath("//span[@class=\"validation-message\"]/text()")[0].strip() ==
+                'Select yes if you have evidence of Nice one')
 
-        assert (doc.cssselect(".govuk-error-message")[1].text_content().strip() ==
-                'Error: You must provide evidence of Top one')
+        assert (doc.xpath("//span[@class=\"validation-message\"]/text()")[1].strip() ==
+                'You must provide evidence of Top one')
         assert len(doc.xpath("//*[@id='input-yesNo-1-1' and @checked]")) == 1
 
-        assert (doc.cssselect(".govuk-error-message")[2].text_content().strip() ==
-                'Error: Your answer must be 100 words or fewer')
+        assert (doc.xpath("//span[@class=\"validation-message\"]/text()")[2].strip() ==
+                'Your answer must be 100 words or fewer')
         assert len(doc.xpath("//*[@id='input-yesNo-2-1' and @checked]")) == 1
         assert doc.xpath("//*[@id='input-evidence-2']/text()")[0] == 'word ' * 100
 
@@ -1215,8 +1215,8 @@ class TestApplyToBrief(BaseApplicationTest):
         assert res.status_code == 400
         doc = html.fromstring(res.get_data(as_text=True))
 
-        assert (doc.cssselect(".govuk-error-message")[0].text_content().strip() ==
-                'Error: Your answer must be 100 words or fewer')
+        assert (doc.xpath("//span[@class=\"validation-message\"]/text()")[0].strip() ==
+                'Your answer must be 100 words or fewer')
         assert doc.xpath("//*[@id='input-evidence-0']/text()")[0] == "over 100 words " * 100
 
         assert len(doc.xpath("//*[@id='input-yesNo-1-2' and @checked]")) == 1


### PR DESCRIPTION
https://trello.com/c/13tOvxuu/285-2-replace-content-loader-form-macros-in-brief-responses-frontend

## Issues
Two cases are not simply dealt with, and I've popped them into a conditional branch on the template.

1. Pricing inputs require a prefix, which is not available in govuk-frontend v2, but is available in v3
2. `niceToHaveRequirements` relies on conditional content, so we want to rework the journey to avoid this.

This makes use of some markdown tweaks in the Frameworks repo: https://github.com/alphagov/digitalmarketplace-frameworks/pull/658 