### PR TITLE
Replace flash messages with alerts

### DIFF
--- a/app/main/views/briefs.py
+++ b/app/main/views/briefs.py
@@ -58,8 +58,6 @@ def ask_brief_clarification_question(brief_id):
     if form.validate_on_submit():
         send_brief_clarification_question(data_api_client, brief, form.clarification_question.data)
         flash(CLARIFICATION_QUESTION_SENT_MESSAGE.format(brief=brief))
-        form_url = url_for('.ask_brief_clarification_question', brief_id=brief_id)
-        flash('{}?submitted=true'.format(form_url), 'track-page-view')
 
     errors = govuk_errors(get_errors_from_wtform(form))
 
@@ -303,9 +301,7 @@ def check_brief_response_answers(brief_id, brief_response_id):
 
         if not error_message:
             flash(APPLICATION_SUBMITTED_FIRST_MESSAGE)
-            # To trigger the analytics Virtual Page View
             redirect_url = url_for('.application_submitted', brief_id=brief_id)
-            flash('{}?result=success'.format(redirect_url), 'track-page-view')
             return redirect(redirect_url)
         else:
             flash(error_message, 'error')

--- a/app/main/views/briefs.py
+++ b/app/main/views/briefs.py
@@ -57,7 +57,7 @@ def ask_brief_clarification_question(brief_id):
     form = AskClarificationQuestionForm(brief)
     if form.validate_on_submit():
         send_brief_clarification_question(data_api_client, brief, form.clarification_question.data)
-        flash(CLARIFICATION_QUESTION_SENT_MESSAGE.format(brief=brief))
+        flash(CLARIFICATION_QUESTION_SENT_MESSAGE.format(brief=brief), "success")
 
     errors = govuk_errors(get_errors_from_wtform(form))
 
@@ -215,7 +215,7 @@ def edit_brief_response(brief_id, brief_response_id, question_id=None):
                 return redirect_to_next_page()
             else:
                 if edit_single_question_flow:
-                    flash(APPLICATION_UPDATED_MESSAGE)
+                    flash(APPLICATION_UPDATED_MESSAGE, "success")
                 return redirect(
                     url_for('.check_brief_response_answers', brief_id=brief_id, brief_response_id=brief_response_id)
                 )
@@ -300,7 +300,7 @@ def check_brief_response_answers(brief_id, brief_response_id):
             error_message = "This opportunity has already closed for applications."
 
         if not error_message:
-            flash(APPLICATION_SUBMITTED_FIRST_MESSAGE)
+            flash(APPLICATION_SUBMITTED_FIRST_MESSAGE, "success")
             redirect_url = url_for('.application_submitted', brief_id=brief_id)
             return redirect(redirect_url)
         else:

--- a/app/templates/_base_page.html
+++ b/app/templates/_base_page.html
@@ -8,6 +8,7 @@
 {% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
 
 {# Import DM components #}
+{% from "digitalmarketplace/components/alert/macro.njk" import dmAlert %}
 {% from "digitalmarketplace/components/cookie-banner/macro.njk" import dmCookieBanner %}
 {% from "digitalmarketplace/components/header/macro.njk" import dmHeader %}
 {% from "digitalmarketplace/components/footer/macro.njk" import dmFooter %}
@@ -48,7 +49,20 @@
 {% endblock %}
 
 {% block content %}
-  {% include "toolkit/flash_messages.html" %}
+  {% block flashMessages %}
+    {% with
+       messages = get_flashed_messages(with_categories=True),
+       titles = {"error": "There is a problem"}
+    %}
+      {% for category, message in messages %}
+        {{ dmAlert({
+          "titleHtml": titles.get(category) or message,
+          "html": message if category in titles else None,
+          "type": category,
+        }) }}
+      {% endfor %}
+    {% endwith %}
+  {% endblock flashMessages %}
   {% block errorSummary %}
     {% if errors %}
       {{ govukErrorSummary({

--- a/tests/app/main/test_briefs.py
+++ b/tests/app/main/test_briefs.py
@@ -1302,7 +1302,7 @@ class TestApplyToBrief(BaseApplicationTest):
             'email@email.com',
         )
         assert res.location == 'http://localhost.localdomain/suppliers/opportunities/1234/responses/result'
-        self.assert_flashes("Your application has been submitted.")
+        self.assert_flashes("Your application has been submitted.", "success")
 
     def test_editing_previously_completed_section_redirects_to_check_your_answers(self):
         data = {'dayRate': '600'}
@@ -1319,7 +1319,7 @@ class TestApplyToBrief(BaseApplicationTest):
         )
         assert res.status_code == 302
         assert res.location == "http://localhost.localdomain/suppliers/opportunities/1234/responses/5/application"
-        self.assert_flashes("Your application has been updated.")
+        self.assert_flashes("Your application has been updated.", "success")
 
 
 class TestCheckYourAnswers(BaseApplicationTest):
@@ -2210,6 +2210,7 @@ class TestResponseResultPage(BaseApplicationTest, BriefResponseTestHelpers):
         # Error flash message should be shown
         flash_messages = doc.cssselect(".dm-alert")
         assert len(flash_messages) == 1
+        assert "dm-alert--error" in flash_messages[0].classes
         assert (
             flash_messages[0].cssselect(".dm-alert__body")[0].text.strip()
             == "This opportunity has already closed for applications."

--- a/tests/app/main/test_briefs.py
+++ b/tests/app/main/test_briefs.py
@@ -300,8 +300,6 @@ class TestSubmitClarificationQuestions(BaseApplicationTest):
                     "The buyer will post your question and their answer on the ‘I need a thing to do a thing’ page."
                 )
             )) == 1
-            assert doc.xpath("//div[@data-analytics='trackPageView']/@data-url")[0] == \
-                '/suppliers/opportunities/1234/ask-a-question?submitted=true'
 
             assert self.notify_client.return_value.send_email.call_args_list == [
                 mock.call(
@@ -2267,11 +2265,6 @@ class TestResponseResultPage(BaseApplicationTest, BriefResponseTestHelpers):
         )
         assert res.status_code == 200
         data = res.get_data(as_text=True)
-        doc = html.fromstring(data)
-
-        # Assert the analytics exists
-        analytics_div = doc.xpath('//div[@data-analytics="trackPageView"]/@data-url')[0]
-        assert analytics_div == '/suppliers/opportunities/1234/responses/result?result=success'
 
         # Assert we get the correct banner message (and only the correct one).
         assert 'Your application has been submitted.' in data

--- a/tests/app/main/test_briefs.py
+++ b/tests/app/main/test_briefs.py
@@ -2208,9 +2208,11 @@ class TestResponseResultPage(BaseApplicationTest, BriefResponseTestHelpers):
         doc = html.fromstring(data)
 
         # Error flash message should be shown
-        assert doc.xpath(
-            "//*[contains(@class, 'banner-destructive-without-action')][normalize-space(string())=$t]",
-            t="This opportunity has already closed for applications.",
+        flash_messages = doc.cssselect(".dm-alert")
+        assert len(flash_messages) == 1
+        assert (
+            flash_messages[0].cssselect(".dm-alert__body")[0].text.strip()
+            == "This opportunity has already closed for applications."
         )
 
         # view shouldn't have bothered calling this


### PR DESCRIPTION
Ticket: https://trello.com/c/n4xGRS3w/283-1-replace-flash-messages-with-digital-marketplace-govuk-frontend-alert-component-in-brief-responses-frontend

We want to use the dmAlerts macro instead of the old flash-messages template, as dmAlert is based on GOV.UK Design System styles and guidance.