### PR TITLE
Bump digitalmarketplace-govuk-frontend from 2.1.0 to 2.9.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2075,9 +2075,9 @@
       }
     },
     "digitalmarketplace-govuk-frontend": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/digitalmarketplace-govuk-frontend/-/digitalmarketplace-govuk-frontend-2.1.0.tgz",
-      "integrity": "sha512-vwObFfAr2c7HEYiw6OpM4YlPiWF4HkG6U0UDKpUrrxARMtD+HnX7HsuQDFBxPCeMAlMtSftIZlzydHe2GwvxZw=="
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/digitalmarketplace-govuk-frontend/-/digitalmarketplace-govuk-frontend-2.9.0.tgz",
+      "integrity": "sha512-PO6l8KDhYUpIcU8bBnkMQE9eAo/JMT473IV26C9y+VLzt0eBVi4S0XpOalWjgCIT8RcQGtmF6vtWXGqPsJqk8Q=="
     },
     "dir-glob": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "del": "^5.1.0",
     "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#v18.0.2",
     "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v36.1.0",
-    "digitalmarketplace-govuk-frontend": "^2.1.0",
+    "digitalmarketplace-govuk-frontend": "^2.9.0",
     "govuk-elements-sass": "3.0.3",
     "govuk-frontend": "^2.13.0",
     "govuk_frontend_toolkit": "5.0.3",


### PR DESCRIPTION
- [Changelog](https://github.com/alphagov/digitalmarketplace-govuk-frontend/blob/master/CHANGELOG.md)