### PR TITLE
Replace summary table on opportunities dashboard

### DIFF
--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -42,9 +42,9 @@ def opportunities_dashboard(framework_slug):
         if opportunity['status'] == 'draft':
             opportunity_row = [
                 {"text": brief.get('title')},
-                {"text": dateformat(applicationsClosedAt), "attributes": {"data-closed": applicationsClosedAt}}
+                {"text": dateformat(applicationsClosedAt), "attributes": {"data-closed": applicationsClosedAt}},
+                {"text": "Draft"},
             ]
-            opportunity_row.append({"text": "Draft"})
 
             # Show applications for live briefs and briefs that closed up to 2 weeks ago
             if opportunity['brief']['status'] == 'live':

--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -1,11 +1,11 @@
 # coding: utf-8
 
 from datetime import datetime, timedelta
-from flask import abort
+from flask import abort, url_for
 from flask_login import current_user
 from dmapiclient import APIError
 from dmutils.flask import timed_render_template as render_template
-from dmutils.formats import DATETIME_FORMAT
+from dmutils.formats import DATETIME_FORMAT, dateformat
 from ... import data_api_client
 from ...main import main
 
@@ -34,15 +34,68 @@ def opportunities_dashboard(framework_slug):
     # Split into two tables by status
     drafts, completed = [], []
     two_weeks_ago = (datetime.now() - timedelta(days=14))
+
     for opportunity in opportunities:
+        brief = opportunity.get('brief')
+        applicationsClosedAt = brief.get("applicationsClosedAt")
+
         if opportunity['status'] == 'draft':
+            opportunity_row = [
+                {"text": brief.get('title')},
+                {"text": dateformat(applicationsClosedAt), "attributes": {"data-closed": applicationsClosedAt}}
+            ]
+            opportunity_row.append({"text": "Draft"})
+
             # Show applications for live briefs and briefs that closed up to 2 weeks ago
             if opportunity['brief']['status'] == 'live':
-                drafts.append(opportunity)
-            elif opportunity['brief']['applicationsClosedAt'] > two_weeks_ago.strftime(DATETIME_FORMAT):
-                drafts.append(opportunity)
+                if opportunity.get("essentialRequirementsMet"):
+                    opportunity_url = url_for(
+                        '.check_brief_response_answers',
+                        brief_id=opportunity.get("briefId"),
+                        brief_response_id=opportunity.get("id")
+                    )
+                else:
+                    opportunity_url = url_for('.start_brief_response', brief_id=opportunity.get("briefId"))
+                opportunity_row.append(
+                    {"html": f'<a class="govuk-link" href="{opportunity_url}">Complete your application</a>'}
+                )
+                drafts.append(opportunity_row)
+            elif applicationsClosedAt > two_weeks_ago.strftime(DATETIME_FORMAT):
+                opportunity_url = url_for(
+                    "external.get_brief_by_id",
+                    framework_family=(brief.get("framework")).get("family"),
+                    brief_id=opportunity.get("briefId")
+                )
+                opportunity_row.append(
+                    {"html": f'<a class="govuk-link" href="{ opportunity_url }">Applications closed</a>'}
+                )
+                drafts.append(opportunity_row)
         else:
-            completed.append(opportunity)
+            opportunity_url = url_for(
+                ".check_brief_response_answers",
+                brief_id=opportunity.get("briefId"),
+                brief_response_id=opportunity.get("id")
+            )
+            opportunity_row = [
+                {"html": f'<a class="govuk-link" href="{ opportunity_url }">{brief.get("title")}</a>'},
+                {"text": dateformat(applicationsClosedAt), "attributes": {"data-closed": applicationsClosedAt}}
+            ]
+
+            status = brief.get("status")
+            if status == "cancelled":
+                opportunity_row.append({"text": "Opportunity cancelled"})
+            elif status == "unsuccessful":
+                opportunity_row.append({"text": "Not won"})
+            elif status == "withdrawn":
+                opportunity_row.append({"text": "Opportunity withdrawn"})
+            elif status == "closed" or status == "live":
+                opportunity_row.append({"text": "Submitted"})
+            elif opportunity.get("status") == "awarded":
+                opportunity_row.append({"text": "Won"})
+            elif status == "awarded":
+                opportunity_row.append({"text": "Not won"})
+
+            completed.append(opportunity_row)
 
     return render_template(
         "frameworks/opportunities_dashboard.html",

--- a/app/templates/_base_page.html
+++ b/app/templates/_base_page.html
@@ -4,6 +4,7 @@
 {% from "govuk/components/breadcrumbs/macro.njk" import govukBreadcrumbs %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
+{% from "govuk/components/table/macro.njk" import govukTable %}
 {% from "govuk/components/input/macro.njk" import govukInput %}
 {% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
 

--- a/app/templates/frameworks/opportunities_dashboard.html
+++ b/app/templates/frameworks/opportunities_dashboard.html
@@ -1,5 +1,4 @@
 {% extends "_base_page.html" %}
-{% import "toolkit/summary-table.html" as summary %}
 
 {% block pageTitle %}
   Opportunities Overview - Digital Marketplace
@@ -27,86 +26,51 @@
 
 {% block mainContent %}
 
-    <div class="govuk-grid-row">
-
-        <div class="govuk-grid-column-two-thirds">
-          <h1 class="govuk-heading-l">Your {{ framework.name }} opportunities</h1>
-        </div>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-l">Your {{ framework.name }} opportunities</h1>
     </div>
+  </div>
 
   <p class="govuk-body">
     <a class="govuk-link" href="{{ url_for('external.list_opportunities', framework_family=framework.family) }}">
       Search for other opportunities
     </a>
   </p>
-
-{{ summary.heading("Applications you’ve started", id="draft-opportunities") }}
-{% call(item) summary.list_table(
-    drafts|sort(attribute='brief.applicationsClosedAt'),
-    caption="Draft opportunities",
-    empty_message="You don’t have any draft applications",
-    field_headings=[
-        "Application",
-        "Deadline",
-        "Status",
-        summary.hidden_field_heading("Complete your draft application")
-    ],
-    field_headings_visible=True
-) %}
-
-    {% call summary.row() %}
-        {% call summary.field(first=True) %}
-            {{ item.brief.title }}
-        {% endcall %}
-        {{ summary.text(item.brief.applicationsClosedAt|dateformat) }}
-        {{ summary.text("Draft") }}
-        {% with url =
-            url_for('.check_brief_response_answers', brief_id=item.briefId, brief_response_id=item.id) if item.essentialRequirementsMet else
-            url_for('.start_brief_response', brief_id=item.briefId)
-        %}
-            {% call summary.field(action=True) %}
-                {% if item.brief.status == 'live' %}
-                    <a class="govuk-link" href="{{ url }}">Complete your application</a>
-                {% else %}
-                    <a class="govuk-link" href="{{ url_for('external.get_brief_by_id', framework_family=item.brief.framework.family, brief_id=item.briefId) }}">Applications closed</a>
-                {% endif %}
-            {% endcall %}
-        {% endwith %}
-    {% endcall %}
-{% endcall %}
-
-{{ summary.heading("Applications you’ve made", id="submitted-opportunities") }}
-{% call(item) summary.list_table(
-    completed|sort(attribute='brief.applicationsClosedAt', reverse=True),
-    caption="Completed opportunities",
-    empty_message="You haven’t applied to any opportunities",
-    field_headings=[
-        "Application",
-        "Deadline",
-        "Status",
-    ],
-    field_headings_visible=True
-) %}
-
-    {% call summary.row() %}
-        {% call summary.field(first=True, wide=True) %}
-            <a class="govuk-link" href="{{ url_for('.check_brief_response_answers', brief_id=item.briefId, brief_response_id=item.id) }}">{{ item.brief.title }}</a>
-        {% endcall %}
-        {{ summary.text(item.brief.applicationsClosedAt|dateformat) }}
-        {% if item.brief.status == "cancelled" %}
-            {{ summary.text('Opportunity cancelled') }}
-        {% elif item.brief.status == "unsuccessful" %}
-            {{ summary.text('Not won') }}
-        {% elif item.brief.status == "withdrawn" %}
-            {{ summary.text('Opportunity withdrawn') }}
-        {% elif item.brief.status == "closed" or item.brief.status == "live" %}
-            {{ summary.text('Submitted') }}
-        {% elif item.status == "awarded" %}
-            {{ summary.text('Won') }}
-        {% elif item.brief.status == "awarded" %}
-            {{ summary.text('Not won') }}
-        {% endif %}
-    {% endcall %}
-{% endcall %}
+  
+  {% if drafts is not defined or not drafts|length %}
+    <h2 class="govuk-heading-m">Applications you’ve started</h2>
+    <p class="govuk-body">You don’t have any draft applications</p>
+  {% else %}
+    {{ govukTable({
+      "attributes": { "id": "draft-opportunities" },
+      "caption": "Applications you’ve started",
+      "captionClasses": "govuk-heading-m",
+      "head": [
+        { "text": "Application" },
+        { "text": "Deadline" },
+        { "text": "Status" },
+        { "text": "" }
+      ],
+      "rows": drafts|sort(attribute="1.attributes.data-closed")
+    })}}
+  {% endif %}
+  
+  {% if completed is not defined or not completed|length %}
+    <h2 class="govuk-heading-m">Applications you’ve made</h2>
+    <p class="govuk-body">You haven’t applied to any opportunities</p>
+  {% else %}
+    {{ govukTable({
+      "attributes": { "id": "submitted-opportunities" },
+      "caption": "Applications you’ve made",
+      "captionClasses": "govuk-heading-m",
+      "head": [
+        { "text": "Application" },
+        { "text": "Deadline" },
+        { "text": "Status" }
+      ],
+      "rows": completed|sort(attribute="1.attributes.data-closed", reverse=True)
+    })}}
+  {% endif %}
 
 {% endblock %}

--- a/requirements.in
+++ b/requirements.in
@@ -11,4 +11,4 @@ gds-metrics==0.2.4
 git+https://github.com/alphagov/digitalmarketplace-utils.git@56.0.0#egg=digitalmarketplace-utils==56.0.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@7.27.1#egg=digitalmarketplace-content-loader==7.27.1
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@21.4.1#egg=digitalmarketplace-apiclient==21.4.1
-git+https://github.com/alphagov/govuk-frontend-jinja.git@v0.5.1-alpha#egg=govuk-frontend-jinja==0.5.1-alpha
+git+https://github.com/alphagov/govuk-frontend-jinja.git@v0.5.7-alpha#egg=govuk-frontend-jinja==0.5.7-alpha

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,7 +29,7 @@ fleep==1.0.1              # via digitalmarketplace-utils
 future==0.18.2            # via notifications-python-client
 gds-metrics==0.2.4        # via -r requirements.in, digitalmarketplace-utils
 govuk-country-register==0.5.0  # via digitalmarketplace-utils
-git+https://github.com/alphagov/govuk-frontend-jinja.git@v0.5.1-alpha#egg=govuk-frontend-jinja==0.5.1-alpha  # via -r requirements.in
+git+https://github.com/alphagov/govuk-frontend-jinja.git@v0.5.7-alpha#egg=govuk-frontend-jinja==0.5.7-alpha # via -r requirements.in
 idna==2.9                 # via requests
 inflection==0.3.1         # via digitalmarketplace-content-loader
 itsdangerous==1.1.0       # via -r requirements.in, flask, flask-wtf

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -127,9 +127,9 @@ class TestOpportunitiesDashboard(BaseApplicationTest):
         assert res.status_code == 200
 
         doc = html.fromstring(res.get_data(as_text=True))
-        xpath_string = ".//*[@id='{}']/following-sibling::table[1]".format(table_id)
+        xpath_string = ".//table[@id='{}']/tbody".format(table_id)
         table = doc.xpath(xpath_string)[0]
-        rows = table.find_class('summary-item-row')
+        rows = table.find_class('govuk-table__row')
         return rows
 
     def test_request_works_and_correct_data_is_fetched(self):
@@ -186,9 +186,9 @@ class TestOpportunitiesDashboard(BaseApplicationTest):
         """Assert the 'Completed opportunities' table on this page contains the correct values."""
         first_row, second_row, third_row = self.get_table_rows_by_id('submitted-opportunities')
 
-        assert 'Highest date, submitted, lowest id' in first_row.text_content()
+        assert 'Highest date, submitted, lowest id' in first_row.text_content().strip()
         assert first_row.xpath('*//a/@href')[0] == '/suppliers/opportunities/100/responses/1/application'
-        assert 'Thursday 8 June 2017' in first_row.text_content()
+        assert 'Thursday 8 June 2017' in first_row.text_content().strip()
 
     def test_completed_list_of_opportunities_ordered_by_applications_closed_at(self):
         """Assert the 'Completed opportunities' table on this page contains the brief responses in the correct order."""


### PR DESCRIPTION
https://trello.com/c/jgoHhWX3/284-3-replace-summary-table-in-opportunities-dashboard-in-brief-responses-frontend

Swapping out Frontend Toolkit summary table for Design System `govukTable`.

## Before

![Screenshot 2020-12-14 at 16 48 33](https://user-images.githubusercontent.com/22524634/102109676-38f51100-3e2c-11eb-8278-275add4b9922.png)

## After
![Screenshot 2020-12-14 at 16 46 31](https://user-images.githubusercontent.com/22524634/102109471-fdf2dd80-3e2b-11eb-93c2-2355953e2ae5.png)
