### PR TITLE
Remove coveralls badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # Digital Marketplace Brief Responses Frontend
 
-[![Coverage Status](https://coveralls.io/repos/github/alphagov/digitalmarketplace-brief-responses-frontend/badge.svg?branch=master)](https://coveralls.io/github/alphagov/digitalmarketplace-brief-responses-frontend?branch=master)
 ![Python 3.6](https://img.shields.io/badge/python-3.6-blue.svg)
 
 Frontend application for the Digital Marketplace.


### PR DESCRIPTION
As of https://github.com/alphagov/digitalmarketplace-brief-responses-frontend/pull/250, we don't use it any more.