### PR TITLE
Bump digitalmarketplace-test-utils from git to PyPI

### DIFF
--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -12,4 +12,4 @@ python-dotenv  # used to load .flaskenv
 requests-mock
 watchdog
 
-git+https://github.com/alphagov/digitalmarketplace-test-utils.git@2.6.1#egg=digitalmarketplace-test-utils==2.6.1
+git+https://github.com/alphagov/digitalmarketplace-test-utils.git@2.8.2#egg=digitalmarketplace-test-utils==2.8.2

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -12,4 +12,4 @@ python-dotenv  # used to load .flaskenv
 requests-mock
 watchdog
 
-git+https://github.com/alphagov/digitalmarketplace-test-utils.git@2.8.2#egg=digitalmarketplace-test-utils==2.8.2
+digitalmarketplace-test-utils

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -20,7 +20,7 @@ click==7.0
     #   pip-tools
 cssselect==1.1.0
     # via -r requirements-dev.in
-git+https://github.com/alphagov/digitalmarketplace-test-utils.git@2.6.1#egg=digitalmarketplace-test-utils==2.6.1
+git+https://github.com/alphagov/digitalmarketplace-test-utils.git@2.8.2#egg=digitalmarketplace-test-utils==2.8.2
     # via -r requirements-dev.in
 entrypoints==0.3
     # via flake8

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -20,7 +20,7 @@ click==7.0
     #   pip-tools
 cssselect==1.1.0
     # via -r requirements-dev.in
-git+https://github.com/alphagov/digitalmarketplace-test-utils.git@2.8.2#egg=digitalmarketplace-test-utils==2.8.2
+digitalmarketplace-test-utils==2.8.2
     # via -r requirements-dev.in
 entrypoints==0.3
     # via flake8

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,39 +4,93 @@
 #
 #    pip-compile requirements-dev.in
 #
-attrs==19.3.0             # via pytest
-certifi==2019.11.28       # via -c requirements.txt, requests
-chardet==3.0.4            # via -c requirements.txt, requests
-click==7.0                # via -c requirements.txt, pip-tools
-cssselect==1.1.0          # via -r requirements-dev.in
-git+https://github.com/alphagov/digitalmarketplace-test-utils.git@2.6.1#egg=digitalmarketplace-test-utils==2.6.1  # via -r requirements-dev.in
-entrypoints==0.3          # via flake8
-flake8==3.7.9             # via -r requirements-dev.in
-freezegun==0.3.15         # via -r requirements-dev.in
-idna==2.9                 # via -c requirements.txt, requests
-importlib-metadata==1.5.0  # via pluggy, pytest
-lxml==4.5.0               # via -r requirements-dev.in
-mccabe==0.6.1             # via flake8
-mock==4.0.1               # via -r requirements-dev.in
-more-itertools==8.2.0     # via pytest
-packaging==20.1           # via pytest
-pathtools==0.1.2          # via watchdog
-pip-tools==5.4.0          # via -r requirements-dev.in
-pluggy==0.13.1            # via pytest
-py==1.8.1                 # via pytest
-pycodestyle==2.5.0        # via flake8
-pyflakes==2.1.1           # via flake8
-pyparsing==2.4.6          # via packaging
-pytest==5.3.5             # via -r requirements-dev.in
-python-dateutil==2.8.1    # via -c requirements.txt, freezegun
-python-dotenv==0.11.0     # via -r requirements-dev.in
-requests-mock==1.7.0      # via -r requirements-dev.in
-requests==2.23.0          # via -c requirements.txt, requests-mock
-six==1.14.0               # via -c requirements.txt, freezegun, packaging, pip-tools, python-dateutil, requests-mock
-urllib3==1.25.10          # via -c requirements.txt, requests
-watchdog==0.10.2          # via -r requirements-dev.in
-wcwidth==0.1.8            # via pytest
-zipp==3.0.0               # via importlib-metadata
+attrs==19.3.0
+    # via pytest
+certifi==2019.11.28
+    # via
+    #   -c requirements.txt
+    #   requests
+chardet==3.0.4
+    # via
+    #   -c requirements.txt
+    #   requests
+click==7.0
+    # via
+    #   -c requirements.txt
+    #   pip-tools
+cssselect==1.1.0
+    # via -r requirements-dev.in
+git+https://github.com/alphagov/digitalmarketplace-test-utils.git@2.6.1#egg=digitalmarketplace-test-utils==2.6.1
+    # via -r requirements-dev.in
+entrypoints==0.3
+    # via flake8
+flake8==3.7.9
+    # via -r requirements-dev.in
+freezegun==0.3.15
+    # via -r requirements-dev.in
+idna==2.9
+    # via
+    #   -c requirements.txt
+    #   requests
+importlib-metadata==1.5.0
+    # via
+    #   pluggy
+    #   pytest
+lxml==4.5.0
+    # via -r requirements-dev.in
+mccabe==0.6.1
+    # via flake8
+mock==4.0.1
+    # via -r requirements-dev.in
+more-itertools==8.2.0
+    # via pytest
+packaging==20.1
+    # via pytest
+pathtools==0.1.2
+    # via watchdog
+pip-tools==5.5.0
+    # via -r requirements-dev.in
+pluggy==0.13.1
+    # via pytest
+py==1.8.1
+    # via pytest
+pycodestyle==2.5.0
+    # via flake8
+pyflakes==2.1.1
+    # via flake8
+pyparsing==2.4.6
+    # via packaging
+pytest==5.3.5
+    # via -r requirements-dev.in
+python-dateutil==2.8.1
+    # via
+    #   -c requirements.txt
+    #   freezegun
+python-dotenv==0.11.0
+    # via -r requirements-dev.in
+requests-mock==1.7.0
+    # via -r requirements-dev.in
+requests==2.23.0
+    # via
+    #   -c requirements.txt
+    #   requests-mock
+six==1.14.0
+    # via
+    #   -c requirements.txt
+    #   freezegun
+    #   packaging
+    #   python-dateutil
+    #   requests-mock
+urllib3==1.25.10
+    # via
+    #   -c requirements.txt
+    #   requests
+watchdog==0.10.2
+    # via -r requirements-dev.in
+wcwidth==0.1.8
+    # via pytest
+zipp==3.0.0
+    # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,56 +4,145 @@
 #
 #    pip-compile requirements.in
 #
-blinker==1.4              # via gds-metrics
-boto3==1.12.3             # via digitalmarketplace-utils
-botocore==1.15.3          # via boto3, s3transfer
-cachelib==0.1.1           # via flask-session
-certifi==2019.11.28       # via requests
-cffi==1.14.0              # via cryptography
-chardet==3.0.4            # via requests
-click==7.0                # via flask
-contextlib2==0.6.0.post1  # via digitalmarketplace-utils
-cryptography==3.2.1       # via digitalmarketplace-utils
-defusedxml==0.6.0         # via odfpy
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@21.4.1#egg=digitalmarketplace-apiclient==21.4.1  # via -r requirements.in
-git+https://github.com/alphagov/digitalmarketplace-content-loader.git@7.27.1#egg=digitalmarketplace-content-loader==7.27.1  # via -r requirements.in
-git+https://github.com/alphagov/digitalmarketplace-utils.git@56.0.0#egg=digitalmarketplace-utils==56.0.0  # via -r requirements.in, digitalmarketplace-content-loader
-docopt==0.6.2             # via notifications-python-client
-docutils==0.15.2          # via botocore
-flask-gzip==0.2           # via digitalmarketplace-utils
-flask-login==0.5.0        # via -r requirements.in, digitalmarketplace-utils
-flask-session==0.3.2      # via digitalmarketplace-utils
-flask-wtf==0.14.3         # via -r requirements.in, digitalmarketplace-utils
-flask==1.0.4              # via -r requirements.in, digitalmarketplace-content-loader, digitalmarketplace-utils, flask-gzip, flask-login, flask-session, flask-wtf, gds-metrics
-fleep==1.0.1              # via digitalmarketplace-utils
-future==0.18.2            # via notifications-python-client
-gds-metrics==0.2.4        # via -r requirements.in, digitalmarketplace-utils
-govuk-country-register==0.5.0  # via digitalmarketplace-utils
-git+https://github.com/alphagov/govuk-frontend-jinja.git@v0.5.7-alpha#egg=govuk-frontend-jinja==0.5.7-alpha  # via -r requirements.in
-idna==2.9                 # via requests
-inflection==0.3.1         # via digitalmarketplace-content-loader
-itsdangerous==1.1.0       # via -r requirements.in, flask, flask-wtf
-jinja2==2.10.3            # via digitalmarketplace-content-loader, flask, govuk-frontend-jinja
-jmespath==0.9.4           # via boto3, botocore
-mailchimp3==3.0.6         # via digitalmarketplace-utils
-markdown==2.6.11          # via digitalmarketplace-content-loader
-markupsafe==1.1.1         # via jinja2
-monotonic==1.5            # via notifications-python-client
-notifications-python-client==5.5.1  # via digitalmarketplace-utils
-odfpy==1.4.1              # via digitalmarketplace-utils
-prometheus-client==0.2.0  # via gds-metrics
-pycparser==2.19           # via cffi
-pyjwt==1.7.1              # via notifications-python-client
-python-dateutil==2.8.1    # via botocore
-python-json-logger==0.1.11  # via digitalmarketplace-utils
-pytz==2019.3              # via digitalmarketplace-utils
-pyyaml==5.3.1             # via digitalmarketplace-content-loader
-redis==3.5.3              # via digitalmarketplace-utils
-requests==2.23.0          # via digitalmarketplace-apiclient, digitalmarketplace-utils, mailchimp3, notifications-python-client
-s3transfer==0.3.3         # via boto3
-six==1.14.0               # via cryptography, python-dateutil
-unicodecsv==0.14.1        # via digitalmarketplace-utils
-urllib3==1.25.10          # via botocore, requests
-werkzeug==1.0.0           # via digitalmarketplace-utils, flask
-workdays==1.4             # via digitalmarketplace-utils
-wtforms==2.2.1            # via flask-wtf
+blinker==1.4
+    # via gds-metrics
+boto3==1.12.3
+    # via digitalmarketplace-utils
+botocore==1.15.3
+    # via
+    #   boto3
+    #   s3transfer
+cachelib==0.1.1
+    # via flask-session
+certifi==2019.11.28
+    # via requests
+cffi==1.14.0
+    # via cryptography
+chardet==3.0.4
+    # via requests
+click==7.0
+    # via flask
+contextlib2==0.6.0.post1
+    # via digitalmarketplace-utils
+cryptography==3.2.1
+    # via digitalmarketplace-utils
+defusedxml==0.6.0
+    # via odfpy
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@21.4.1#egg=digitalmarketplace-apiclient==21.4.1
+    # via -r requirements.in
+git+https://github.com/alphagov/digitalmarketplace-content-loader.git@7.27.1#egg=digitalmarketplace-content-loader==7.27.1
+    # via -r requirements.in
+git+https://github.com/alphagov/digitalmarketplace-utils.git@56.0.0#egg=digitalmarketplace-utils==56.0.0
+    # via
+    #   -r requirements.in
+    #   digitalmarketplace-content-loader
+docopt==0.6.2
+    # via notifications-python-client
+docutils==0.15.2
+    # via botocore
+flask-gzip==0.2
+    # via digitalmarketplace-utils
+flask-login==0.5.0
+    # via
+    #   -r requirements.in
+    #   digitalmarketplace-utils
+flask-session==0.3.2
+    # via digitalmarketplace-utils
+flask-wtf==0.14.3
+    # via
+    #   -r requirements.in
+    #   digitalmarketplace-utils
+flask==1.0.4
+    # via
+    #   -r requirements.in
+    #   digitalmarketplace-content-loader
+    #   digitalmarketplace-utils
+    #   flask-gzip
+    #   flask-login
+    #   flask-session
+    #   flask-wtf
+    #   gds-metrics
+fleep==1.0.1
+    # via digitalmarketplace-utils
+future==0.18.2
+    # via notifications-python-client
+gds-metrics==0.2.4
+    # via
+    #   -r requirements.in
+    #   digitalmarketplace-utils
+govuk-country-register==0.5.0
+    # via digitalmarketplace-utils
+git+https://github.com/alphagov/govuk-frontend-jinja.git@v0.5.7-alpha#egg=govuk-frontend-jinja==0.5.7-alpha
+    # via -r requirements.in
+idna==2.9
+    # via requests
+inflection==0.3.1
+    # via digitalmarketplace-content-loader
+itsdangerous==1.1.0
+    # via
+    #   -r requirements.in
+    #   flask
+    #   flask-wtf
+jinja2==2.10.3
+    # via
+    #   digitalmarketplace-content-loader
+    #   flask
+    #   govuk-frontend-jinja
+jmespath==0.9.4
+    # via
+    #   boto3
+    #   botocore
+mailchimp3==3.0.6
+    # via digitalmarketplace-utils
+markdown==2.6.11
+    # via digitalmarketplace-content-loader
+markupsafe==1.1.1
+    # via jinja2
+monotonic==1.5
+    # via notifications-python-client
+notifications-python-client==5.5.1
+    # via digitalmarketplace-utils
+odfpy==1.4.1
+    # via digitalmarketplace-utils
+prometheus-client==0.2.0
+    # via gds-metrics
+pycparser==2.19
+    # via cffi
+pyjwt==1.7.1
+    # via notifications-python-client
+python-dateutil==2.8.1
+    # via botocore
+python-json-logger==0.1.11
+    # via digitalmarketplace-utils
+pytz==2019.3
+    # via digitalmarketplace-utils
+pyyaml==5.3.1
+    # via digitalmarketplace-content-loader
+redis==3.5.3
+    # via digitalmarketplace-utils
+requests==2.23.0
+    # via
+    #   digitalmarketplace-apiclient
+    #   digitalmarketplace-utils
+    #   mailchimp3
+    #   notifications-python-client
+s3transfer==0.3.3
+    # via boto3
+six==1.14.0
+    # via
+    #   cryptography
+    #   python-dateutil
+unicodecsv==0.14.1
+    # via digitalmarketplace-utils
+urllib3==1.25.10
+    # via
+    #   botocore
+    #   requests
+werkzeug==1.0.0
+    # via
+    #   digitalmarketplace-utils
+    #   flask
+workdays==1.4
+    # via digitalmarketplace-utils
+wtforms==2.2.1
+    # via flask-wtf


### PR DESCRIPTION
We want to install digitalmarketplace-test-utils from PyPI instead of VCS, so we can rely on Dependabot to update our apps automatically when a new version is available.