### PR TITLE
Replace summary table for Check Your Answers

### DIFF
--- a/app/assets/scss/application.scss
+++ b/app/assets/scss/application.scss
@@ -57,6 +57,7 @@ $govuk-global-styles: true;
 @import "overrides/_pricing-input";
 @import "overrides/_hint";
 @import "overrides/_dm-table";
+@import "overrides/_summary-list";
 
 // Misc styles
 // TODO: Move misc styling into their own partial files or the Digital Marketplace FE Toolkit

--- a/app/assets/scss/application.scss
+++ b/app/assets/scss/application.scss
@@ -56,6 +56,7 @@ $govuk-global-styles: true;
 @import "overrides/_notification-banner";
 @import "overrides/_pricing-input";
 @import "overrides/_hint";
+@import "overrides/_dm-table";
 
 // Misc styles
 // TODO: Move misc styling into their own partial files or the Digital Marketplace FE Toolkit

--- a/app/assets/scss/overrides/_dm-table.scss
+++ b/app/assets/scss/overrides/_dm-table.scss
@@ -1,0 +1,8 @@
+/**
+ * On the Check Your Answers page, we use a table to display the evidence answers, since
+ * these require hedings. We also need to display an action link - in order to make this look
+ * like summary list action links, we align it to the right.
+ */
+.dm-table-head-link {
+    text-align: right
+}

--- a/app/assets/scss/overrides/_summary-list.scss
+++ b/app/assets/scss/overrides/_summary-list.scss
@@ -1,0 +1,9 @@
+/*
+ * On the Check Your Answers page, we want to de-bold the Details table so that it's
+ * not confusing for users having both cell headers and column headers in the tables
+ */
+ .app-govuk-summary-list .govuk-summary-list__key {
+    @include govuk-media-query($from: tablet) {
+        font-weight: $govuk-font-weight-regular;
+    }
+}

--- a/app/templates/_base_page.html
+++ b/app/templates/_base_page.html
@@ -5,6 +5,7 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 {% from "govuk/components/table/macro.njk" import govukTable %}
+{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 {% from "govuk/components/input/macro.njk" import govukInput %}
 {% from "govuk/components/character-count/macro.njk" import govukCharacterCount %}
 {% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}

--- a/app/templates/briefs/_brief_response_data.html
+++ b/app/templates/briefs/_brief_response_data.html
@@ -1,112 +1,107 @@
-{% import "toolkit/summary-table.html" as summary %}
 {% for section in response_content.summary(brief_response) %}
 
+  {# Don't have a table for nice-to-have requirements if none have been given #}
+  {% if not (section.id == 'your-nice-to-have-skills-and-experience' and not brief['niceToHaveRequirements']|length) %}
+    {# Use a govukTable for evidence questions, since they have defined columns. Otherwise use a govukSummaryList. #}
     {% if section.id in ("your-nice-to-have-skills-and-experience", "your-essential-skills-and-experience") and ('essentialRequirementsMet' in brief_response) %}
-      {% set field_headings = ["Requirement", "Evidence"] %}
-      {% set field_headings_visible = True %}
-    {% else %}
-      {% set field_headings = ["Opportunity attribute name", "Opportunity attribute value", "Edit link"] %}
-      {% set field_headings_visible = False %}
-    {% endif %}
+      {% set top_change_link %}
+        {% if show_edit_links %}
+          <a 
+            href="{{url_for('.edit_single_question', brief_id=brief.id, brief_response_id=brief_response.id, question_id=section.questions[0].id)}}"
+            data-analytics="trackEvent"
+            data-analytics-category="internal-link"
+            data-analytics_action="Edit Supplier Application"
+            data-analytics_label="{{brief_response.status}}"
+          >Change
+          <span class="govuk-visually-hidden">{{section.name}}</span>
+          </a>
+        {% endif %}
+      {% endset %}
 
-    {# Don't have a table for nice-to-have requirements if none have been given #}
-    {% if not (section.id == 'your-nice-to-have-skills-and-experience' and not brief['niceToHaveRequirements']|length) %}
+      {% set followup_questions_already_displayed = [] %}
 
-        {{ summary.heading(section.name, id="opportunity-attributes-{}".format(loop.index)) }}
-
-        {% call(item) summary.list_table(
-          section.questions,
-          caption=section.name,
-          field_headings=field_headings,
-          field_headings_visible=field_headings_visible
-        ) %}
-            {% if item.type == "boolean_list" %}
-
-              {% if show_edit_links %}
-                {{ summary.top_link(
-                    "Edit",
-                    url_for('.edit_single_question', brief_id=brief.id, brief_response_id=brief_response.id, question_id=item.id),
-                    analytics="trackEvent",
-                    analytics_category="internal-link",
-                    analytics_action="Edit Supplier Application",
-                    analytics_label=brief_response.status,
-                    hidden_text=section.name
-                  )
-                }}
-              {% endif %}
-
-              {% for question in item.boolean_list_questions %}
-                {% call summary.row() %}
-                  {{ summary.field_name(question, two_thirds=True) }}
-                  {{ summary['boolean'](item.value[loop.index0]) }}
-                {% endcall %}
+      {% set ns = namespace(rows = []) %}
+      {% for question in section.questions %}
+        {% for subquestion in question.questions %}
+          {% if subquestion.type == "boolean" %}
+            {% if subquestion._data['followup'] is defined %}
+              {% for followup_question in subquestion._data['followup'] %}
+                {% set followup_questions_already_displayed = followup_questions_already_displayed.extend([followup_question]) %}
+                  {% set row = ns.rows.append(
+                    [
+                      {"text": subquestion.label, "classes": "govuk-!-width-one-third"},
+                      {"text": section.unformat_data(brief_response)[followup_question]},
+                      {"text": ""} if show_edit_links
+                    ]
+                  )%}
               {% endfor %}
-
-            {% elif item.type == "dynamic_list" %}
-
-              {% set followup_questions_already_displayed = [] %}
-
-              {% if show_edit_links %}
-                {{ summary.top_link(
-                    "Edit",
-                    url_for('.edit_single_question', brief_id=brief.id, brief_response_id=brief_response.id, question_id=item.id),
-                    analytics="trackEvent",
-                    analytics_category="internal-link",
-                    analytics_action="Edit Supplier Application",
-                    analytics_label=brief_response.status,
-                    hidden_text=section.name
-                  )
-                }}
-              {% endif %}
-
-              {% for question in item.questions %}
-                  {% if question.type == "boolean" %}
-
-                    {% if question._data['followup'] is defined %}
-                      {% for followup_question in question._data['followup'] %}
-                        {% call summary.row() %}
-                          {# Keep track of the questions we are displaying here, so we know to skip them as we
-                              continue to loop through item.questions #}
-                          {% set followup_questions_already_displayed = followup_questions_already_displayed.extend([followup_question]) %}
-
-                          {{ summary.field_name(question.question) }}
-                          {{ summary.text(item.unformat_data(brief_response)[followup_question] | preserve_line_breaks) }}
-                        {% endcall %}
-                      {% endfor %}
-                    {% endif %}
-
-                  {% else %}
-
-                    {# If we have seen this question before, let's not display it again. #}
-                    {% if question.id not in followup_questions_already_displayed %}
-                      {% call summary.row() %}
-                        {{ summary.field_name(question.question) }}
-                        {{ summary.text(item.unformat_data(brief_response)[question.id] | preserve_line_breaks) }}
-                      {% endcall %}
-                    {% endif %}
-
-                  {% endif %}
-              {% endfor %}
-
-            {% else %}
-
-              {% call summary.row() %}
-                {{ summary.field_name(item.label) }}
-                {{ summary[item.type](item.value) }}
-                {% if show_edit_links %}
-                   {% call summary.field(action=True) %}
-                      <a class="govuk-link" href="{{ url_for('.edit_single_question', brief_id=brief.id, brief_response_id=brief_response.id, question_id=item.id) }}"
-                        data-analytics="trackEvent"
-                        data-analytics-category="internal-link"
-                        data-analytics-action="Edit Supplier Application"
-                        data-analytics-label="{{ brief_response.status }}"
-                      >Edit<span class="visually-hidden"> {{ item.label }}</span></a>
-                    {% endcall %}
-                {% endif %}
-              {% endcall %}
-
             {% endif %}
-        {% endcall %}
+          {% else %}
+            {% if subquestion.id not in followup_questions_already_displayed %}
+              {% set row = ns.rows.append(
+                [
+                  {"text": subquestion.label, "classes": "govuk-!-width-one-third"},
+                  {"text": question.unformat_data(brief_response).get(subquestion.id) | preserve_line_breaks},
+                  {"text": ""} if show_edit_links
+                ]
+              )%}
+            {% endif %}
+          {% endif %}
+        {% endfor %}
+      {% endfor %}
 
+      {{govukTable({
+        "caption": section.name,
+        "captionClasses": "govuk-heading-m",
+        "head": [
+          {"text": "Requirement"},
+          {"text": "Evidence"},
+          {"html": top_change_link, "classes": "dm-table-head-link"}
+        ],
+        "rows": ns.rows
+      })}}
+
+    {% else %}
+      {% set ns = namespace(rows = []) %}
+      {% for question in section.questions %}
+        {% if show_edit_links %}
+          {% set row = ns.rows.append(
+            {
+              "key": {"text": question.label, "classes": "govuk-!-width-one-third"},
+              "value": {"text": question.value},
+              "actions": {
+                "items": [
+                  {
+                    "href": url_for(".edit_single_question", brief_id=brief.id, brief_response_id=brief_response.id, question_id=question.id),
+                    "text": "Change",
+                    "visuallyHiddenText": question.label,
+                    "attributes": {
+                      "data-analytics": "trackEvent",
+                      "data-analytics-category": "internal-link",
+                      "data-analytics_action": "Edit Supplier Application",
+                      "data-analytics_label": brief_response["status"]
+                    }
+                  }
+                ]
+              }
+            }
+          )%}
+        {% else %}
+          {% set row = ns.rows.append(
+            {
+              "key": {"text": question.label, "classes": "govuk-!-width-one-third"},
+              "value": {"text": question.value}
+            }
+          )%}
+        {% endif%}
+      {% endfor %}
+
+      <h2 class="govuk-heading-m">{{ section.name }}</h2>
+      {{ govukSummaryList({
+        "rows": ns.rows
+      })}}
     {% endif %}
+
+  {% endif %}
+
 {% endfor %}

--- a/app/templates/briefs/_brief_response_data.html
+++ b/app/templates/briefs/_brief_response_data.html
@@ -4,7 +4,7 @@
   {% if not (section.id == 'your-nice-to-have-skills-and-experience' and not brief['niceToHaveRequirements']|length) %}
     {# Use a govukTable for evidence questions, since they have defined columns. Otherwise use a govukSummaryList. #}
     {% if section.id in ("your-nice-to-have-skills-and-experience", "your-essential-skills-and-experience") and ('essentialRequirementsMet' in brief_response) %}
-      {% set top_change_link %}
+      {% set top_edit_link %}
         {% if show_edit_links %}
           <a 
             href="{{url_for('.edit_single_question', brief_id=brief.id, brief_response_id=brief_response.id, question_id=section.questions[0].id)}}"
@@ -12,7 +12,7 @@
             data-analytics-category="internal-link"
             data-analytics_action="Edit Supplier Application"
             data-analytics_label="{{brief_response.status}}"
-          >Change
+          >Edit
           <span class="govuk-visually-hidden">{{section.name}}</span>
           </a>
         {% endif %}
@@ -56,7 +56,7 @@
         "head": [
           {"text": "Requirement"},
           {"text": "Evidence"},
-          {"html": top_change_link, "classes": "dm-table-head-link"}
+          {"html": top_edit_link, "classes": "dm-table-head-link"}
         ],
         "rows": ns.rows
       })}}
@@ -73,7 +73,7 @@
                 "items": [
                   {
                     "href": url_for(".edit_single_question", brief_id=brief.id, brief_response_id=brief_response.id, question_id=question.id),
-                    "text": "Change",
+                    "text": "Edit",
                     "visuallyHiddenText": question.label,
                     "attributes": {
                       "data-analytics": "trackEvent",

--- a/app/templates/briefs/_brief_response_data.html
+++ b/app/templates/briefs/_brief_response_data.html
@@ -98,6 +98,7 @@
 
       <h2 class="govuk-heading-m">{{ section.name }}</h2>
       {{ govukSummaryList({
+        "classes": "app-govuk-summary-list",
         "rows": ns.rows
       })}}
     {% endif %}

--- a/requirements.in
+++ b/requirements.in
@@ -11,4 +11,4 @@ gds-metrics==0.2.4
 git+https://github.com/alphagov/digitalmarketplace-utils.git@56.0.0#egg=digitalmarketplace-utils==56.0.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@7.27.1#egg=digitalmarketplace-content-loader==7.27.1
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@21.4.1#egg=digitalmarketplace-apiclient==21.4.1
-git+https://github.com/alphagov/govuk-frontend-jinja.git@v0.5.7-alpha#egg=govuk-frontend-jinja==0.5.7-alpha
+git+https://github.com/alphagov/govuk-frontend-jinja.git@v0.5.8-alpha#egg=govuk-frontend-jinja==0.5.8-alpha

--- a/requirements.txt
+++ b/requirements.txt
@@ -72,7 +72,7 @@ gds-metrics==0.2.4
     #   digitalmarketplace-utils
 govuk-country-register==0.5.0
     # via digitalmarketplace-utils
-git+https://github.com/alphagov/govuk-frontend-jinja.git@v0.5.7-alpha#egg=govuk-frontend-jinja==0.5.7-alpha
+git+https://github.com/alphagov/govuk-frontend-jinja.git@v0.5.8-alpha#egg=govuk-frontend-jinja==0.5.8-alpha
     # via -r requirements.in
 idna==2.9
     # via requests

--- a/tests/app/main/test_briefs.py
+++ b/tests/app/main/test_briefs.py
@@ -1404,7 +1404,7 @@ class TestCheckYourAnswers(BaseApplicationTest):
         res = self.client.get('/suppliers/opportunities/1234/responses/5/application')
         doc = html.fromstring(res.get_data(as_text=True))
         edit_application_links = [
-            anchor.get('href') for anchor in doc.xpath('//a') if 'Change' in anchor.text_content()
+            anchor.get('href') for anchor in doc.xpath('//a') if 'Edit' in anchor.text_content()
         ]
         if edit_links_shown:
             assert edit_application_links == [

--- a/tests/app/main/test_briefs.py
+++ b/tests/app/main/test_briefs.py
@@ -69,7 +69,8 @@ class Table(object):
                 self._data.append(
                     [
                         element.find('span').text if element.find('span') is not None
-                        else '' for element in row_element.findall('td')]
+                        else '' for element in row_element.findall('td')
+                    ]
                 )
 
     def exists(self):
@@ -87,6 +88,42 @@ class Table(object):
                 return self._data[self._row_index][idx]
             except IndexError as e:
                 raise IndexError("{}. Contents of table: {}".format(e, self._data))
+
+
+class GovUkTable(Table):
+    def __init__(self, doc, table_name):
+        self._data = []
+        self._row_index = None
+
+        query = doc.xpath(f'//table[caption="{table_name}"]/tbody/tr')
+        if len(query):
+            for row_element in query:
+                self._data.append(
+                    [
+                        element.text or '' for element in row_element.findall('td')
+                    ]
+                )
+
+
+class GovUkSummaryList(Table):
+    def __init__(self, doc, table_name):
+        self._data = []
+        self._row_index = None
+
+        query = doc.xpath(
+            (
+                f'//h2[contains(normalize-space(text()), "{table_name}")]'
+                '/following-sibling::dl[1]/div'
+            )
+        )
+        if len(query):
+            for row_element in query:
+                cell_elements = row_element.xpath('dt | dd')
+                self._data.append(
+                    [
+                        element.text.strip() for element in cell_elements
+                    ]
+                )
 
 
 class TestBriefQuestionAndAnswerSession(BaseApplicationTest):
@@ -1366,7 +1403,9 @@ class TestCheckYourAnswers(BaseApplicationTest):
         )
         res = self.client.get('/suppliers/opportunities/1234/responses/5/application')
         doc = html.fromstring(res.get_data(as_text=True))
-        edit_application_links = [anchor.get('href') for anchor in doc.xpath('//a') if 'Edit' in anchor.text_content()]
+        edit_application_links = [
+            anchor.get('href') for anchor in doc.xpath('//a') if 'Change' in anchor.text_content()
+        ]
         if edit_links_shown:
             assert edit_application_links == [
                 '/suppliers/opportunities/1234/responses/5/dayRate/edit',
@@ -1421,7 +1460,7 @@ class TestCheckYourAnswers(BaseApplicationTest):
         res = self.client.get('/suppliers/opportunities/1234/responses/5/application')
         doc = html.fromstring(res.get_data(as_text=True))
 
-        requirements_data = Table(doc, "Your essential skills and experience")
+        requirements_data = GovUkTable(doc, "Your essential skills and experience")
         assert requirements_data.exists()
         assert requirements_data.row(0).cell(1) == "nice valid evidence"
         assert requirements_data.row(1).cell(1) == "more valid evidence"
@@ -1443,7 +1482,7 @@ class TestCheckYourAnswers(BaseApplicationTest):
         assert res.status_code == 200
         doc = html.fromstring(res.get_data(as_text=True))
 
-        requirements_data = Table(doc, "Your nice-to-have skills and experience")
+        requirements_data = GovUkTable(doc, "Your nice-to-have skills and experience")
         assert requirements_data.exists()
         assert requirements_data.row(0).cell(1) == ""
         assert requirements_data.row(1).cell(1) == "nice valid evidence"
@@ -1510,7 +1549,7 @@ class TestCheckYourAnswers(BaseApplicationTest):
         assert res.status_code == 200
         doc = html.fromstring(res.get_data(as_text=True))
 
-        requirements_data = Table(doc, "Your details")
+        requirements_data = GovUkSummaryList(doc, "Your details")
         assert requirements_data.exists()
         assert requirements_data.row(0).cell(0) == "Day rate"
         assert requirements_data.row(0).cell(1) == "£300"
@@ -1670,7 +1709,7 @@ class TestCheckYourAnswers(BaseApplicationTest):
             'Your nice-to-have skills and experience',
             'Your details',
         ]
-        requirements_data = Table(doc, "Your details")
+        requirements_data = GovUkSummaryList(doc, "Your details")
         assert requirements_data.row(1).cell(0) == "Date the specialist can start work"
 
     def test_check_your_answers_page_renders_for_incomplete_brief_responses(self):


### PR DESCRIPTION
https://trello.com/c/2oltxnyO/299-3-replace-summary-table-on-check-your-answers-in-brief-responses-frontend

I investigated moving the logic for this into the controller, but that resulted in a raft of helper functions drowning in loops and branches.

So instead, I'm using Jinja's namespace to create the rows object within the template and pass it to the GOVUK Frontend components.

I haven't handled the `boolean_list` case because this only applies to DOS1, for which this page doesn't appear to be accessible anymore (since the dashboard only shows the live Framework plus the previous one). See https://github.com/alphagov/digitalmarketplace-frameworks/search?q=boolean_list

Because of these changes, we need some tweaks to the functional tests: https://github.com/alphagov/digitalmarketplace-functional-tests/pull/834