### PR TITLE
Remove frontend toolkit typography styles

### DIFF
--- a/app/templates/briefs/application_submitted.html
+++ b/app/templates/briefs/application_submitted.html
@@ -33,55 +33,56 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
 
-      <div class="dmspeak">
-        <h1 class="govuk-heading-l">What happens next<h1>
+    <h1 class="govuk-heading-l">What happens next<h1>
 
-        <h2 class="heading-xmedium">Shortlist</h2>
+    <h2 class="govuk-heading-m">Shortlist</h2>
 
-        <p class="govuk-body">When the opportunity closes, the buyer will score your evidence. If you’re one of the top {{ brief.get('numberOfSuppliers') }} suppliers, you'll go through to the evaluation stage.</p>
-        <p class="govuk-body">The buyer will tell you if you're not successful.</p>
+    <p class="govuk-body">When the opportunity closes, the buyer will score your evidence. If you’re one of the top {{ brief.get('numberOfSuppliers') }} suppliers, you'll go through to the evaluation stage.</p>
+    <p class="govuk-body">The buyer will tell you if you're not successful.</p>
 
-        <h2 class="heading-xmedium">Evaluation</h2>
+    <h2 class="govuk-heading-m">Evaluation</h2>
 
-        <div class="explanation-list">
-          <p class="govuk-body">At the evaluation stage, the buyer will ask you to provide:</p>
-          <ul class="govuk-list govuk-list--bullet">
-            <li>
-            {% if brief.lotSlug == "digital-specialists" %}
-              evidence of the specialist’s skills and experience
-            {% else %}
-              evidence of your skills and experience
-            {% endif %}
-            </li>
-            {% if brief.lotSlug != "digital-specialists" %}
-            <li>your proposal</li>
-            {% endif %}
-          </ul>
-        </div>
-        <div class="explanation-list">
-          <p class="govuk-body">The buyer will use the assessment methods listed in their requirements to evaluate your evidence. They’ll use:</p>
-          <ul class="govuk-list govuk-list--bullet">
-            {% for eval_type in brief_summary.get_question('evaluationType').value %}
-              <li>{{ 'an' if eval_type == 'Interview' else 'a' }} {{ eval_type|lower }}</li>
-            {% endfor %}
-          </ul>
-        </div>
-        <p class="govuk-body">
-          Your evidence must describe the skills and experience of the {{ 'person' if brief.lotSlug == "digital-specialists" else 'people' }} who’ll be working on the project.
-        </p>
-        <p class="govuk-body">
-          The buyer will score all suppliers who reached the evaluation stage using the weightings they published with their requirements. They’ll provide feedback if you’re unsuccessful.
-        </p>
-      </div>
+    <p class="govuk-body">At the evaluation stage, the buyer will ask you to provide:</p>
+    <ul class="govuk-list govuk-list--bullet">
+      <li>
+      {% if brief.lotSlug == "digital-specialists" %}
+        evidence of the specialist’s skills and experience
+      {% else %}
+        evidence of your skills and experience
+      {% endif %}
+      </li>
+      {% if brief.lotSlug != "digital-specialists" %}
+      <li>your proposal</li>
+      {% endif %}
+    </ul>
+
+    {% if brief_summary.get_question('evaluationType').value %}
+    <p class="govuk-body">The buyer will use the assessment methods listed in their requirements to evaluate your evidence. They’ll use:</p>
+    <ul class="govuk-list govuk-list--bullet">
+      {% for eval_type in brief_summary.get_question('evaluationType').value %}
+        <li>{{ 'an' if eval_type == 'Interview' else 'a' }} {{ eval_type|lower }}</li>
+      {% endfor %}
+    </ul>
+    {% endif %}
+
+    <p class="govuk-body">
+      Your evidence must describe the skills and experience of the {{ 'person' if brief.lotSlug == "digital-specialists" else 'people' }} who’ll be working on the project.
+    </p>
+    <p class="govuk-body">
+      The buyer will score all suppliers who reached the evaluation stage using the weightings they published with their requirements. They’ll provide feedback if you’re unsuccessful.
+    </p>
+
+    <p class="govuk-body">
+      <a
+        class="govuk-link govuk-link--no-visited-state"
+        href="{{ url_for('.opportunities_dashboard', framework_slug=brief.frameworkSlug) }}"
+      >
+        Return to your opportunities
+      </a>
+    </p>
 
   </div>
 </div>
 
-<a
-  class="govuk-link govuk-link--no-visited-state govuk-!-margin-top-6 govuk-!-display-inline-block"
-  href="{{ url_for('.opportunities_dashboard', framework_slug=brief.frameworkSlug) }}"
->
-  Return to your opportunities
-</a>
 
 {% endblock %}

--- a/app/templates/briefs/clarification_question.html
+++ b/app/templates/briefs/clarification_question.html
@@ -24,35 +24,35 @@
 
 {% block mainContent %}
 
-<div class="single-question-page">
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
 
-      <form method="post" action="{{ request.path }}" novalidate>
-        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
+    <form method="post" action="{{ request.path }}" novalidate>
+      <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
 
-        {{ govukCharacterCount({
-          "label": {
-            "text": form.clarification_question.question,
-            "isPageHeading": True,
-            "classes": "govuk-label--l"
-          },
-          "hint": {
-            "html": form.clarification_question.question_advice,
-            "classes": "dm-question-advice"
-          },
-          "errorMessage": errors.clarification_question.errorMessage,
-          "id": "input-clarification_question",
-          "name": "clarification_question",
-          "value": form.clarification_question.data if form.clarification_question.data,
-          "maxwords": 100
-        }) }}
+      {{ govukCharacterCount({
+        "label": {
+          "text": form.clarification_question.question,
+          "isPageHeading": True,
+          "classes": "govuk-label--l"
+        },
+        "hint": {
+          "html": form.clarification_question.question_advice,
+          "classes": "dm-question-advice"
+        },
+        "errorMessage": errors.clarification_question.errorMessage,
+        "id": "input-clarification_question",
+        "name": "clarification_question",
+        "value": form.clarification_question.data if form.clarification_question.data,
+        "maxwords": 100
+      }) }}
 
-        {{ govukButton({"text": "Ask question"}) }}
-      </form>
+      {{ govukButton({"text": "Ask question"}) }}
+    </form>
 
+    <p class="govuk-body">
       <a class="govuk-link" href="{{ url_for('external.get_brief_by_id', framework_family=brief.framework.family, brief_id=brief.id) }}">Return to {{ brief.title }}</a>
-    </div>
+    </p>
   </div>
 </div>
 {% endblock %}

--- a/app/templates/briefs/question_and_answer_session.html
+++ b/app/templates/briefs/question_and_answer_session.html
@@ -30,13 +30,13 @@
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l">‘{{ brief.title }}’ question and answer session details</h1>
 
-    <div class="padding-bottom-small">
-      <p class="govuk-body">
-        {{ brief.questionAndAnswerSessionDetails }}
-      </p>
-    </div>
+    <p class="govuk-body">
+      {{ brief.questionAndAnswerSessionDetails }}
+    </p>
 
-    <a class="govuk-link" href="{{ url_for('external.get_brief_by_id', framework_family=brief.framework.family, brief_id=brief.id) }}">Return to {{ brief.title }}</a>
+    <p class="govuk-body">
+      <a class="govuk-link" href="{{ url_for('external.get_brief_by_id', framework_family=brief.framework.family, brief_id=brief.id) }}">Return to {{ brief.title }}</a>
+    </p>
   </div>
 </div>
 {% endblock %}


### PR DESCRIPTION
https://trello.com/c/LdwIhKyT/295-2-remove-old-styles-and-dmspeak-from-brief-responses-frontend

`check_your_answers` and `base_edit_question_page` will be covered in separate PRs (`check_your_answers`: #255), so I've only removed these styles from other templates.