### PR TITLE
Load DOS 5 content 

### DIFF
--- a/app/main/__init__.py
+++ b/app/main/__init__.py
@@ -36,6 +36,10 @@ def _make_content_loader_factory():
     master_cl.load_manifest('digital-outcomes-and-specialists-4', 'brief-responses', 'edit_brief_response')
     master_cl.load_manifest('digital-outcomes-and-specialists-4', 'brief-responses', 'display_brief_response')
 
+    master_cl.load_manifest('digital-outcomes-and-specialists-5', 'briefs', 'edit_brief')
+    master_cl.load_manifest('digital-outcomes-and-specialists-5', 'brief-responses', 'edit_brief_response')
+    master_cl.load_manifest('digital-outcomes-and-specialists-5', 'brief-responses', 'display_brief_response')
+
     # seal master_cl in a closure by returning a function which will only ever return an independent copy of it
     return lambda: deepcopy(master_cl)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2063,8 +2063,8 @@
       "dev": true
     },
     "digitalmarketplace-frameworks": {
-      "version": "git+https://github.com/alphagov/digitalmarketplace-frameworks.git#8578fc0abd5581a6c375a3712bdca904ce5a9673",
-      "from": "git+https://github.com/alphagov/digitalmarketplace-frameworks.git#v18.0.5"
+      "version": "git+https://github.com/alphagov/digitalmarketplace-frameworks.git#f4f21674fb33c32394b1a1e1c09059ebd8bd41e0",
+      "from": "git+https://github.com/alphagov/digitalmarketplace-frameworks.git#v18.1.6"
     },
     "digitalmarketplace-frontend-toolkit": {
       "version": "git+https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#323b3d4b704e33782df6cdae7b105a2a9237a594",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "colors": "1.1.2",
     "del": "^5.1.0",
-    "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#v18.0.5",
+    "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#v18.1.6",
     "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v36.1.0",
     "digitalmarketplace-govuk-frontend": "^2.9.0",
     "govuk-elements-sass": "3.0.3",


### PR DESCRIPTION
This is needed for making DOS 5 live. I don't know how/why we missed doing it earlier. Should un-break Preview.

Following the example from DOS 4: https://github.com/alphagov/digitalmarketplace-brief-responses-frontend/pull/127