### PR TITLE
Bump content loader patch version

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -9,6 +9,6 @@ itsdangerous==1.1.0
 gds-metrics==0.2.4
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@56.0.0#egg=digitalmarketplace-utils==56.0.0
-git+https://github.com/alphagov/digitalmarketplace-content-loader.git@7.27.1#egg=digitalmarketplace-content-loader==7.27.1
+git+https://github.com/alphagov/digitalmarketplace-content-loader.git@7.27.2#egg=digitalmarketplace-content-loader==7.27.2
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@21.4.1#egg=digitalmarketplace-apiclient==21.4.1
 git+https://github.com/alphagov/govuk-frontend-jinja.git@v0.5.8-alpha#egg=govuk-frontend-jinja==0.5.8-alpha

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,7 +30,7 @@ defusedxml==0.6.0
     # via odfpy
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@21.4.1#egg=digitalmarketplace-apiclient==21.4.1
     # via -r requirements.in
-git+https://github.com/alphagov/digitalmarketplace-content-loader.git@7.27.1#egg=digitalmarketplace-content-loader==7.27.1
+git+https://github.com/alphagov/digitalmarketplace-content-loader.git@7.27.2#egg=digitalmarketplace-content-loader==7.27.2
     # via -r requirements.in
 git+https://github.com/alphagov/digitalmarketplace-utils.git@56.0.0#egg=digitalmarketplace-utils==56.0.0
     # via


### PR DESCRIPTION
This picks up changes in https://github.com/alphagov/digitalmarketplace-content-loader/pull/124
which prevented users from being able to submit a brief response.