### PR TITLE
Bump digitalmarketplace-frameworks version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2063,8 +2063,8 @@
       "dev": true
     },
     "digitalmarketplace-frameworks": {
-      "version": "git+https://github.com/alphagov/digitalmarketplace-frameworks.git#f4f21674fb33c32394b1a1e1c09059ebd8bd41e0",
-      "from": "git+https://github.com/alphagov/digitalmarketplace-frameworks.git#v18.1.6"
+      "version": "git+https://github.com/alphagov/digitalmarketplace-frameworks.git#26b376bf1ec406da53491d8398d882552a2fff1c",
+      "from": "git+https://github.com/alphagov/digitalmarketplace-frameworks.git#v18.1.7"
     },
     "digitalmarketplace-frontend-toolkit": {
       "version": "git+https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#323b3d4b704e33782df6cdae7b105a2a9237a594",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "colors": "1.1.2",
     "del": "^5.1.0",
-    "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#v18.1.6",
+    "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#v18.1.7",
     "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v36.1.0",
     "digitalmarketplace-govuk-frontend": "^2.9.0",
     "govuk-elements-sass": "3.0.3",


### PR DESCRIPTION
Pick up the updated example content added in https://github.com/alphagov/digitalmarketplace-frameworks/pull/666

https://trello.com/c/bQUiYaju/702-update-date-examples-to-2021