### PR TITLE
Use render_question() to get HTML for multiquestion forms

### DIFF
--- a/app/templates/briefs/_base_edit_question_page.html
+++ b/app/templates/briefs/_base_edit_question_page.html
@@ -88,22 +88,13 @@
 
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
-          {% if question.type != 'multiquestion' %}
-            {{ render_question(question, service_data, errors) }}
-          {% else %}
-            {% if question.question_advice %}
-              {{ question.question_advice }}
-            {% endif %}
-            {% for question in question.questions %}
-              {{ render_question(question, service_data, errors, is_page_heading=False) }}
-            {% endfor %}
-          {% endif %}
+          {{ render_question(question, service_data, errors) }}
           <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
           {% block save_button %}{% endblock %}
         </div>
       </div>
 
     </form>
-  
+
   {% endif %}
 {% endblock %}

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,7 +30,7 @@ defusedxml==0.6.0
     # via odfpy
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@21.4.1#egg=digitalmarketplace-apiclient==21.4.1
     # via -r requirements.in
-digitalmarketplace-content-loader==7.28.1
+digitalmarketplace-content-loader==7.29.0
     # via -r requirements.in
 git+https://github.com/alphagov/digitalmarketplace-utils.git@56.0.0#egg=digitalmarketplace-utils==56.0.0
     # via


### PR DESCRIPTION
digitalmarketplace-content-loader>=7.29.0 supports multiquestions, we can get rid of (some of) the special logic in `_base_edit_question_page.html`.