### PR TITLE
Use render_question() for niceToHaveRequirements

### DIFF
--- a/app/templates/briefs/_base_edit_question_page.html
+++ b/app/templates/briefs/_base_edit_question_page.html
@@ -16,8 +16,7 @@
 {% block mainContent %}
 
   <!-- Pricing questions use a prefix, which is available in govuk-frontend v3, but not in v2. -->
-  <!-- niceToHaveRequirements uses followup/reveal questions which are not in scope -->
-  {% if question.type == 'pricing' or question.id == 'niceToHaveRequirements' %}
+  {% if question.type == 'pricing' %}
 
     {% if question.type != 'multiquestion' %}
       <div class="single-question-page">

--- a/app/templates/briefs/_base_edit_question_page.html
+++ b/app/templates/briefs/_base_edit_question_page.html
@@ -15,7 +15,7 @@
 
 {% block mainContent %}
 
-  <!-- Pricing questions use a prefix, which is available in govuk-frontend v3, but not in v2. -->
+  {# Pricing questions use a prefix, which is available in govuk-frontend v3, but not in v2. #}
   {% if question.type == 'pricing' %}
 
     {% if question.type != 'multiquestion' %}

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,7 +30,7 @@ defusedxml==0.6.0
     # via odfpy
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@21.4.1#egg=digitalmarketplace-apiclient==21.4.1
     # via -r requirements.in
-digitalmarketplace-content-loader==7.29.0
+digitalmarketplace-content-loader==7.30.0
     # via -r requirements.in
 git+https://github.com/alphagov/digitalmarketplace-utils.git@56.0.0#egg=digitalmarketplace-utils==56.0.0
     # via

--- a/tests/app/main/test_briefs.py
+++ b/tests/app/main/test_briefs.py
@@ -1110,8 +1110,7 @@ class TestApplyToBrief(BaseApplicationTest):
         )
         assert res.status_code == 200
         doc = html.fromstring(res.get_data(as_text=True))
-        questions = doc.xpath(
-            "//*[@class='question-heading']/text()")
+        questions = [e.text.strip() for e in doc.cssselect("[class=govuk-label],.govuk-fieldset__legend")]
         questions = list(map(str.strip, questions))
 
         assert questions == [
@@ -1207,15 +1206,13 @@ class TestApplyToBrief(BaseApplicationTest):
                 'Your answer must be 100 words or fewer')
 
         # Test individual questions errors and prefilled content
-        assert (doc.xpath("//span[@class=\"validation-message\"]/text()")[0].strip() ==
-                'Select yes if you have evidence of Nice one')
+        error_messages = [e.text_content().strip() for e in doc.cssselect("span.govuk-error-message")]
+        assert error_messages[0] == "Error: Select yes if you have evidence of Nice one"
 
-        assert (doc.xpath("//span[@class=\"validation-message\"]/text()")[1].strip() ==
-                'You must provide evidence of Top one')
+        assert error_messages[1] == "Error: You must provide evidence of Top one"
         assert len(doc.xpath("//*[@id='input-yesNo-1-1' and @checked]")) == 1
 
-        assert (doc.xpath("//span[@class=\"validation-message\"]/text()")[2].strip() ==
-                'Your answer must be 100 words or fewer')
+        assert error_messages[2] == "Error: Your answer must be 100 words or fewer"
         assert len(doc.xpath("//*[@id='input-yesNo-2-1' and @checked]")) == 1
         assert doc.xpath("//*[@id='input-evidence-2']/text()")[0] == 'word ' * 100
 
@@ -1248,8 +1245,8 @@ class TestApplyToBrief(BaseApplicationTest):
         assert res.status_code == 400
         doc = html.fromstring(res.get_data(as_text=True))
 
-        assert (doc.xpath("//span[@class=\"validation-message\"]/text()")[0].strip() ==
-                'Your answer must be 100 words or fewer')
+        assert doc.cssselect("span.govuk-error-message")[0].text_content().strip() \
+            == "Error: Your answer must be 100 words or fewer"
         assert doc.xpath("//*[@id='input-evidence-0']/text()")[0] == "over 100 words " * 100
 
         assert len(doc.xpath("//*[@id='input-yesNo-1-2' and @checked]")) == 1


### PR DESCRIPTION
Ticket: https://trello.com/c/cMtAeSL2/764-3-add-support-for-conditionally-revealed-content-to-dmcontentgovukfronted

Depends on https://github.com/alphagov/digitalmarketplace-content-loader/pull/132

digitalmarketplace-content-loader>=7.30.0 supports followup questions in multiquestions, so we can use it to display the `niceToHaveRequirements` question.