### PR TITLE
remove unneeded ubuntu dependencies

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,9 +9,6 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - name: Install Ubuntu packages
-      run: sudo apt-get install libxml2-dev libxslt1-dev python-dev
-
     - name: Install Node dependencies
       shell: bash -l {0}
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,29 +9,39 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - name: Install Node dependencies
-      shell: bash -l {0}
-      run: |
-        nvm install
-        make npm-install
-    - uses: actions/cache@v2
+    - name: Setup Node cache
+      uses: actions/cache@v2
+      id: node-cache
       with:
         path: ~/.npm
         key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
         restore-keys: |
           ${{ runner.os }}-node-
+
+    - name: Setup Python cache
+      uses: actions/cache@v2
+      id: python-cache
+      with:
+        path: venv
+        key: venv-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('**/requirements*.txt') }}
+        restore-keys: venv-${{ runner.os }}-${{ matrix.python-version }}-
+
     - name: Setup python (${{ matrix.python-version }})
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
 
-    - name: Setup Python cache
-      uses: actions/cache@v2
-      with:
-        path: venv
-        key: venv-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('**/requirements*.txt') }}
+    - name: Install Node version
+      shell: bash -l {0}
+      run: nvm install
 
-    - name: Run python tests
-      run: |
-        make requirements-dev
-        make test
+    - name: Install Node dependencies
+      run:  make npm-install
+      if: steps.node-cache.outputs.cache-hit != 'true'
+
+    - name: Install dependencies
+      run: make requirements-dev
+      if: steps.python-cache.outputs.cache-hit != 'true'
+
+    - name: Run tests
+      run: make test


### PR DESCRIPTION
Since `lxml` upgrade in #259  we no longer need additional ubuntu dependencies to build against python 3.9.