### PR TITLE
use node 14 LTS

### DIFF
--- a/.nvmrc
+++ b/.nvmrc
@@ -1,1 +1,1 @@
-10.19.0
+lts/fermium


### PR DESCRIPTION
https://trello.com/c/0BmkYFSD/907-3-node-10-is-eol-april-2021-upgrade-node-to-v14  
Run Node 14 LTS locally first before trying it on docker/PaaS.