### PR TITLE
Remove success flash when updating brief response

### DIFF
--- a/app/main/views/briefs.py
+++ b/app/main/views/briefs.py
@@ -23,7 +23,6 @@ from ..forms.briefs import AskClarificationQuestionForm
 PUBLISHED_BRIEF_STATUSES = ['live', 'closed', 'awarded', 'cancelled', 'unsuccessful', 'withdrawn']
 
 APPLICATION_SUBMITTED_FIRST_MESSAGE = "Your application has been submitted."
-APPLICATION_UPDATED_MESSAGE = "Your application has been updated."
 CLARIFICATION_QUESTION_SENT_MESSAGE = "Your question has been sent. " \
                                       "The buyer will post your question and their answer on the ‘{brief[title]}’ page."
 
@@ -208,8 +207,6 @@ def edit_brief_response(brief_id, brief_response_id, question_id=None):
             if next_question_id and not edit_single_question_flow:
                 return redirect_to_next_page()
             else:
-                if edit_single_question_flow:
-                    flash(APPLICATION_UPDATED_MESSAGE, "success")
                 return redirect(
                     url_for('.check_brief_response_answers', brief_id=brief_id, brief_response_id=brief_response_id)
                 )

--- a/tests/app/main/test_briefs.py
+++ b/tests/app/main/test_briefs.py
@@ -1359,7 +1359,6 @@ class TestApplyToBrief(BaseApplicationTest):
         )
         assert res.status_code == 302
         assert res.location == "http://localhost.localdomain/suppliers/opportunities/1234/responses/5/application"
-        self.assert_flashes("Your application has been updated.", "success")
 
 
 class TestCheckYourAnswers(BaseApplicationTest):


### PR DESCRIPTION
https://trello.com/c/FGm8bi13/3-2-suppliers-may-be-missing-out-on-opportunities-due-to-misleading-banner

We believe that this success flash message is misleading some suppliers. We have some evidence to suggest that they think the flash message means that they've successfully submitted their brief response. This means that they don't press the button to submit their application.

Our evidence here is not definitive - we've got a pattern of support requests, but we've not done any user research or proper analysis.

We don't need this flash, however. Users can see on the page that their information has been updated.

For this reason, we're just going to go ahead and remove the flash. We'll check back in a few weeks to see what effect it's had on the rate of submitted brief responses and support requests.

This screenshot shows the green flash message that this PR removes:

![image_(7)](https://user-images.githubusercontent.com/15256121/122257754-34d3aa00-cec8-11eb-9289-454e69c1ef92.png)
